### PR TITLE
Add plugin to detect unnamed groups in rewrite targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Gixy-Next can detect a wide range of NGINX security and performance misconfigura
 *   [[status_page_exposed] Ensures that status_page is not exposed to the world](https://gixy.io/plugins/status_page_exposed/)
 *   [[try_files_is_evil_too] `try_files` directive is evil without open_file_cache](https://gixy.io/plugins/try_files_is_evil_too/)
 *   [[unanchored_regex] Unanchored regular expressions](https://gixy.io/plugins/unanchored_regex/)
+*   [[unnamed_groups] Unnamed capture groups in rewrite query string](https://gixy.io/plugins/unnamed_groups/)
 *   [[valid_referers] none in valid_referers](https://gixy.io/plugins/valid_referers/)
 *   [[version_disclosure] Using insecure values for server_tokens](https://gixy.io/plugins/version_disclosure/)
 *   [[worker_rlimit_nofile_vs_connections] `worker_rlimit_nofile` must be at least twice `worker_connections`](https://gixy.io/plugins/worker_rlimit_nofile_vs_connections/)

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -110,6 +110,7 @@ Gixy-Next can detect a wide range of NGINX security and performance misconfigura
 *   [[status_page_exposed] Ensures that status_page is not exposed to the world](https://gixy.io/plugins/status_page_exposed/)
 *   [[try_files_is_evil_too] `try_files` directive is evil without open_file_cache](https://gixy.io/plugins/try_files_is_evil_too/)
 *   [[unanchored_regex] Unanchored regular expressions](https://gixy.io/plugins/unanchored_regex/)
+*   [[unnamed_groups] Unnamed capture groups in rewrite query string](https://gixy.io/plugins/unnamed_groups/)
 *   [[valid_referers] none in valid_referers](https://gixy.io/plugins/valid_referers/)
 *   [[version_disclosure] Using insecure values for server_tokens](https://gixy.io/plugins/version_disclosure/)
 *   [[worker_rlimit_nofile_vs_connections] `worker_rlimit_nofile` must be at least twice `worker_connections`](https://gixy.io/plugins/worker_rlimit_nofile_vs_connections/)

--- a/docs/en/plugins/unnamed_groups.md
+++ b/docs/en/plugins/unnamed_groups.md
@@ -1,54 +1,41 @@
 ---
 title: "Unnamed capture groups in rewrite with query string"
-description: "Detects rewrite directives that combine a '?' in the replacement URL with numeric capture group references ($1, $2, …) — the pattern exploited by CVE-2026-42945 ('nginx rift')."
+description: "Detects rewrite directives that use numeric capture group references ($1, $2, …) in a replacement URL that also contains a query string — the pattern associated with CVE-2026-42945."
 ---
 
 # [unnamed_groups] Unnamed capture groups in rewrite with query string
 
 ## What this check looks for
 
-This plugin flags `rewrite` directives where the replacement URL contains a `?` **and** any numeric capture group reference (`$1`, `$2`, …) appears anywhere in that replacement — before or after the `?`.
+This plugin flags `rewrite` directives where the replacement URL contains a `?` and also references positional capture groups (`$1`, `$2`, …) anywhere in that replacement — before or after the `?`.
 
 ## Why this is a problem
 
-CVE-2026-42945 ("nginx rift") is a heap buffer overflow in `ngx_http_rewrite_module`. The bug arises from a two-pass mismatch: the buffer length is calculated using the raw (unescaped) size of capture group values, but the copy applies `NGX_ESCAPE_ARGS` escaping — which is triggered by the presence of `?` anywhere in the replacement string. Characters like `%`, `+`, and `&` in attacker-controlled values expand from 1 to 3 bytes, overflowing the buffer. The overflow affects **all** `$N` references in the replacement, including those that appear before the `?`.
+This pattern is associated with CVE-2026-42945 ("nginx rift"), which can crash or allow code execution in nginx worker processes on affected versions. Whether a given deployment is vulnerable depends on the nginx version — Gixy-Next cannot determine this from the config alone, so this is reported as **INFORMATION**.
 
-## Why this is informational
-
-Whether a given deployment is actually exploitable depends entirely on the nginx version and whether the relevant patch has been applied — information that is not present in a config file. Gixy-Next therefore reports this at **INFORMATION** severity rather than as a confirmed vulnerability.
-
-The recommended fix — switching from positional (`$1`, `$2`) to named capture groups — also improves readability. This benefit applies regardless of nginx version.
+Switching to named capture groups eliminates the pattern entirely and also makes the rewrite easier to read.
 
 ## Bad configuration
 
-`$N` in the query string (the obvious case):
-
 ```nginx
+# $1 and $2 in the query string
 rewrite ^/users/([0-9]+)/profile/(.*)$ /profile.php?id=$1&tab=$2 last;
-```
 
-`$N` in the path portion — also vulnerable because `?` is present in the replacement:
-
-```nginx
+# $1 in the path — also flagged when ? is present anywhere in the replacement
 rewrite ^/(.*)$ /$1?v=2 last;
 ```
 
 ## Better configuration
 
-Use named capture groups and reference them by name:
-
 ```nginx
 rewrite ^/users/(?<id>[0-9]+)/profile/(?<tab>.*)$ /profile.php?id=$id&tab=$tab last;
-```
 
-```nginx
 rewrite ^/(?<path>.*)$ /$path?v=2 last;
 ```
 
 ## Additional notes
 
-- The trigger is the presence of `?` in the replacement. Without `?`, positional references are safe even with the same regex.
-- Named capture group references (e.g., `$id`, `$path`) do not go through the vulnerable code path and are not flagged.
-- Nginx built-in variables such as `$arg_id` are not positional capture references and are not flagged.
+- Rewrites with no `?` in the replacement are not flagged, even if they use positional captures.
+- Named capture group references (`$id`, `$path`, etc.) and nginx built-in variables (`$arg_id`, etc.) are not flagged.
 - Affected versions: NGINX Open Source 0.6.27–1.30.0 (fixed in 1.30.1/1.31.0), NGINX Plus R32–R36.
 - For more information see [CVE-2026-42945 on NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-42945).

--- a/docs/en/plugins/unnamed_groups.md
+++ b/docs/en/plugins/unnamed_groups.md
@@ -1,0 +1,48 @@
+---
+title: "Unnamed capture groups in rewrite query string"
+description: "Detects rewrite directives that reference numeric capture groups ($1, $2, …) in the query-string portion of the replacement URL — the pattern associated with CVE-2026-42945 ('nginx rift')."
+---
+
+# [unnamed_groups] Unnamed capture groups in rewrite query string
+
+## What this check looks for
+
+This plugin flags `rewrite` directives where numeric capture group references (`$1`, `$2`, …) appear **after the `?`** in the replacement URL — the specific pattern associated with CVE-2026-42945.
+
+## Why this is informational
+
+CVE-2026-42945 ("nginx rift") is a vulnerability in nginx itself, not in the configuration. Whether a given deployment is actually exploitable depends entirely on the nginx version and whether the relevant patch has been applied — information that is not present in a config file. Gixy-Next therefore reports this at **INFORMATION** severity rather than as a confirmed vulnerability.
+
+The recommended fix — switching from positional (`$1`, `$2`) to named capture groups — also improves readability by making the purpose of each substitution explicit. This benefit applies regardless of nginx version.
+
+## Bad configuration
+
+```nginx
+server {
+    location / {
+        rewrite ^/users/([0-9]+)/profile/(.*)$ /profile.php?id=$1&tab=$2 last;
+    }
+}
+```
+
+`$1` and `$2` are positional references to unnamed capture groups. When they appear in the query string portion of the replacement URL this matches the CVE-2026-42945 pattern.
+
+## Better configuration
+
+Use named capture groups and reference them by name:
+
+```nginx
+server {
+    location / {
+        rewrite ^/users/(?<id>[0-9]+)/profile/(?<tab>.*)$ /profile.php?id=$id&tab=$tab last;
+    }
+}
+```
+
+This eliminates the CVE-2026-42945 pattern entirely and makes the intent of each substitution self-documenting.
+
+## Additional notes
+
+- Only references appearing **after the `?`** in the replacement URL are flagged. Positional references in the path portion (before `?`) are not part of the CVE pattern and are not reported.
+- Variables that contain digits but are not positional capture group references (e.g., `$arg_id`, `$http2_push`) are not flagged.
+- For more information see [CVE-2026-42945 on NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-42945).

--- a/docs/en/plugins/unnamed_groups.md
+++ b/docs/en/plugins/unnamed_groups.md
@@ -11,9 +11,9 @@ This plugin flags `rewrite` directives where the replacement URL contains a `?` 
 
 ## Why this is a problem
 
-This pattern is associated with CVE-2026-42945 ("nginx rift"), which can crash or allow code execution in nginx worker processes on affected versions. Whether a given deployment is vulnerable depends on the nginx version — Gixy-Next cannot determine this from the config alone, so this is reported as **INFORMATION**.
+CVE-2026-42945 ("nginx rift") is a bug in nginx itself. The only real fix is to update nginx to a patched version. Whether a given deployment is vulnerable depends on the nginx version — Gixy-Next cannot determine this from the config alone, so this is reported as **INFORMATION**.
 
-Switching to named capture groups eliminates the pattern entirely and also makes the rewrite easier to read.
+Switching to named capture groups avoids the vulnerable pattern on unpatched versions and is worth doing regardless: `$id` and `$tab` are self-documenting in a way that `$1` and `$2` are not, making rewrites easier to understand and maintain.
 
 ## Bad configuration
 

--- a/docs/en/plugins/unnamed_groups.md
+++ b/docs/en/plugins/unnamed_groups.md
@@ -1,48 +1,54 @@
 ---
-title: "Unnamed capture groups in rewrite query string"
-description: "Detects rewrite directives that reference numeric capture groups ($1, $2, …) in the query-string portion of the replacement URL — the pattern associated with CVE-2026-42945 ('nginx rift')."
+title: "Unnamed capture groups in rewrite with query string"
+description: "Detects rewrite directives that combine a '?' in the replacement URL with numeric capture group references ($1, $2, …) — the pattern exploited by CVE-2026-42945 ('nginx rift')."
 ---
 
-# [unnamed_groups] Unnamed capture groups in rewrite query string
+# [unnamed_groups] Unnamed capture groups in rewrite with query string
 
 ## What this check looks for
 
-This plugin flags `rewrite` directives where numeric capture group references (`$1`, `$2`, …) appear **after the `?`** in the replacement URL — the specific pattern associated with CVE-2026-42945.
+This plugin flags `rewrite` directives where the replacement URL contains a `?` **and** any numeric capture group reference (`$1`, `$2`, …) appears anywhere in that replacement — before or after the `?`.
+
+## Why this is a problem
+
+CVE-2026-42945 ("nginx rift") is a heap buffer overflow in `ngx_http_rewrite_module`. The bug arises from a two-pass mismatch: the buffer length is calculated using the raw (unescaped) size of capture group values, but the copy applies `NGX_ESCAPE_ARGS` escaping — which is triggered by the presence of `?` anywhere in the replacement string. Characters like `%`, `+`, and `&` in attacker-controlled values expand from 1 to 3 bytes, overflowing the buffer. The overflow affects **all** `$N` references in the replacement, including those that appear before the `?`.
 
 ## Why this is informational
 
-CVE-2026-42945 ("nginx rift") is a vulnerability in nginx itself, not in the configuration. Whether a given deployment is actually exploitable depends entirely on the nginx version and whether the relevant patch has been applied — information that is not present in a config file. Gixy-Next therefore reports this at **INFORMATION** severity rather than as a confirmed vulnerability.
+Whether a given deployment is actually exploitable depends entirely on the nginx version and whether the relevant patch has been applied — information that is not present in a config file. Gixy-Next therefore reports this at **INFORMATION** severity rather than as a confirmed vulnerability.
 
-The recommended fix — switching from positional (`$1`, `$2`) to named capture groups — also improves readability by making the purpose of each substitution explicit. This benefit applies regardless of nginx version.
+The recommended fix — switching from positional (`$1`, `$2`) to named capture groups — also improves readability. This benefit applies regardless of nginx version.
 
 ## Bad configuration
 
+`$N` in the query string (the obvious case):
+
 ```nginx
-server {
-    location / {
-        rewrite ^/users/([0-9]+)/profile/(.*)$ /profile.php?id=$1&tab=$2 last;
-    }
-}
+rewrite ^/users/([0-9]+)/profile/(.*)$ /profile.php?id=$1&tab=$2 last;
 ```
 
-`$1` and `$2` are positional references to unnamed capture groups. When they appear in the query string portion of the replacement URL this matches the CVE-2026-42945 pattern.
+`$N` in the path portion — also vulnerable because `?` is present in the replacement:
+
+```nginx
+rewrite ^/(.*)$ /$1?v=2 last;
+```
 
 ## Better configuration
 
 Use named capture groups and reference them by name:
 
 ```nginx
-server {
-    location / {
-        rewrite ^/users/(?<id>[0-9]+)/profile/(?<tab>.*)$ /profile.php?id=$id&tab=$tab last;
-    }
-}
+rewrite ^/users/(?<id>[0-9]+)/profile/(?<tab>.*)$ /profile.php?id=$id&tab=$tab last;
 ```
 
-This eliminates the CVE-2026-42945 pattern entirely and makes the intent of each substitution self-documenting.
+```nginx
+rewrite ^/(?<path>.*)$ /$path?v=2 last;
+```
 
 ## Additional notes
 
-- Only references appearing **after the `?`** in the replacement URL are flagged. Positional references in the path portion (before `?`) are not part of the CVE pattern and are not reported.
-- Variables that contain digits but are not positional capture group references (e.g., `$arg_id`, `$http2_push`) are not flagged.
+- The trigger is the presence of `?` in the replacement. Without `?`, positional references are safe even with the same regex.
+- Named capture group references (e.g., `$id`, `$path`) do not go through the vulnerable code path and are not flagged.
+- Nginx built-in variables such as `$arg_id` are not positional capture references and are not flagged.
+- Affected versions: NGINX Open Source 0.6.27–1.30.0 (fixed in 1.30.1/1.31.0), NGINX Plus R32–R36.
 - For more information see [CVE-2026-42945 on NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-42945).

--- a/gixy/plugins/unnamed_groups.py
+++ b/gixy/plugins/unnamed_groups.py
@@ -15,9 +15,9 @@ class unnamed_groups(Plugin):
     severity = gixy.severity.INFORMATION
     description = (
         "Using numeric capture groups ($1, $2, …) in a rewrite replacement that "
-        "contains a query string ('?') is associated with CVE-2026-42945. Whether "
-        "the instance is exploitable depends on the nginx version. Switching to named "
-        "capture groups is the recommended fix and also improves readability."
+        "contains a query string ('?') is associated with CVE-2026-42945 — a bug in "
+        "nginx itself, fixed by updating nginx. Switching to named capture groups "
+        "avoids the pattern on unpatched versions and improves readability."
     )
     help_url = "https://gixy.io/plugins/unnamed_groups/"
     directives = ["rewrite"]

--- a/gixy/plugins/unnamed_groups.py
+++ b/gixy/plugins/unnamed_groups.py
@@ -5,31 +5,38 @@ from gixy.plugins.plugin import Plugin
 
 
 class unnamed_groups(Plugin):
+    r"""
+    Detects rewrite directives that reference numeric capture groups ($1, $2, …)
+    in the query-string portion of the replacement URL — the pattern associated
+    with CVE-2026-42945 ("nginx rift").
+
+    Whether any given nginx build is exploitable depends entirely on the nginx
+    version and patch status, which cannot be determined from a config file.
+    This finding is therefore informational: switching to named capture groups
+    is the recommended fix and also improves readability independent of the CVE.
+
+    Flagged:
+        rewrite ^/users/([0-9]+)/profile/(.*)$ /profile.php?id=$1&tab=$2 last;
+
+    Preferred:
+        rewrite ^/users/(?<id>[0-9]+)/profile/(?<tab>.*)$ /profile.php?id=$id&tab=$tab last;
     """
-    Detects rewrite groups vulnerable to CVE-2026-42945
 
-    rewrite ^/users/([0-9]+)/profile/(.*)$ /profile.php?id=$1&tab=$2 last;
-
-    Directives like this where there is an unnamed group referenced after a "?"
-    in the target are vulnerable.
-    """
-
-    summary = "Using numeric regex capture groups in a rewrite query string."
-    severity = gixy.severity.MEDIUM
+    summary = "Numeric capture group reference in rewrite query string (CVE-2026-42945)."
+    severity = gixy.severity.INFORMATION
     description = (
-        "Referencing numeric capture groups (like $1, $2) after a ? in a rewrite "
-        "target can expose rewrite handling issues."
+        "Referencing numeric capture groups ($1, $2, …) after a '?' in a rewrite "
+        "replacement is the pattern targeted by CVE-2026-42945 ('nginx rift'). "
+        "Whether the instance is exploitable depends on the nginx version and patch "
+        "status, which is not visible in the config. Switching to named capture groups "
+        "is the recommended mitigation and also improves readability."
     )
     help_url = "https://gixy.io/plugins/unnamed_groups/"
     directives = ["rewrite"]
 
-    CAPTURE_GROUP_REF = re.compile(r"\$([1-9]\d*)")
+    _CAPTURE_GROUP_REF = re.compile(r"\$([1-9]\d*)")
 
     def audit(self, directive):
-        if directive.name == "rewrite":
-            self._audit_rewrite(directive)
-
-    def _audit_rewrite(self, directive):
         if len(directive.args) < 2:
             return
 
@@ -38,13 +45,15 @@ class unnamed_groups(Plugin):
             return
 
         query_string = replacement.split("?", 1)[1]
-        capture_refs = self.CAPTURE_GROUP_REF.findall(query_string)
+        capture_refs = self._CAPTURE_GROUP_REF.findall(query_string)
         if not capture_refs:
             return
 
         refs = ", ".join(f"${ref}" for ref in capture_refs)
-        reason = (
-            f"The rewrite target references numeric capture group(s) {refs} "
-            "after a ? in the replacement URL."
+        self.add_issue(
+            directive=directive,
+            reason=(
+                f"Rewrite target uses numeric capture group(s) {refs} in the query "
+                "string. See CVE-2026-42945."
+            ),
         )
-        self.add_issue(directive=directive, reason=reason)

--- a/gixy/plugins/unnamed_groups.py
+++ b/gixy/plugins/unnamed_groups.py
@@ -1,0 +1,50 @@
+import re
+
+import gixy
+from gixy.plugins.plugin import Plugin
+
+
+class unnamed_groups(Plugin):
+    """
+    Detects rewrite groups vulnerable to CVE-2026-42945
+
+    rewrite ^/users/([0-9]+)/profile/(.*)$ /profile.php?id=$1&tab=$2 last;
+
+    Directives like this where there is an unnamed group referenced after a "?"
+    in the target are vulnerable.
+    """
+
+    summary = "Using numeric regex capture groups in a rewrite query string."
+    severity = gixy.severity.MEDIUM
+    description = (
+        "Referencing numeric capture groups (like $1, $2) after a ? in a rewrite "
+        "target can expose rewrite handling issues."
+    )
+    help_url = "https://gixy.io/plugins/unnamed_groups/"
+    directives = ["rewrite"]
+
+    CAPTURE_GROUP_REF = re.compile(r"\$([1-9]\d*)")
+
+    def audit(self, directive):
+        if directive.name == "rewrite":
+            self._audit_rewrite(directive)
+
+    def _audit_rewrite(self, directive):
+        if len(directive.args) < 2:
+            return
+
+        replacement = directive.args[1]
+        if "?" not in replacement:
+            return
+
+        query_string = replacement.split("?", 1)[1]
+        capture_refs = self.CAPTURE_GROUP_REF.findall(query_string)
+        if not capture_refs:
+            return
+
+        refs = ", ".join(f"${ref}" for ref in capture_refs)
+        reason = (
+            f"The rewrite target references numeric capture group(s) {refs} "
+            "after a ? in the replacement URL."
+        )
+        self.add_issue(directive=directive, reason=reason)

--- a/gixy/plugins/unnamed_groups.py
+++ b/gixy/plugins/unnamed_groups.py
@@ -6,41 +6,18 @@ from gixy.plugins.plugin import Plugin
 
 class unnamed_groups(Plugin):
     r"""
-    Detects rewrite directives that combine a query string ('?') in the
-    replacement URL with numeric capture group references ($1, $2, …) anywhere
-    in that replacement — the pattern exploited by CVE-2026-42945 ("nginx rift").
-
-    The bug is a heap buffer overflow in ngx_http_rewrite_module: the length
-    calculation for capture group values uses the raw byte count, but the copy
-    applies NGX_ESCAPE_ARGS escaping (triggered by the presence of '?'), so
-    characters like '%', '+', and '&' expand from 1 to 3 bytes and overflow the
-    buffer. The overflow affects ALL $N references in the replacement, including
-    those that appear before the '?'.
-
-    Whether any given nginx build is exploitable depends entirely on the nginx
-    version and patch status, which cannot be determined from a config file.
-    This finding is therefore informational: switching to named capture groups
-    is the recommended fix and also improves readability independent of the CVE.
-
-    Flagged ($N after ?):
+    Insecure examples:
         rewrite ^/users/([0-9]+)/profile/(.*)$ /profile.php?id=$1&tab=$2 last;
-
-    Also flagged ($N before ?):
         rewrite ^/(.*)$ /$1?v=2 last;
-
-    Preferred (named captures):
-        rewrite ^/users/(?<id>[0-9]+)/profile/(?<tab>.*)$ /profile.php?id=$id&tab=$tab last;
     """
 
     summary = "Unnamed capture group reference in rewrite with query string (CVE-2026-42945)."
     severity = gixy.severity.INFORMATION
     description = (
-        "When a rewrite replacement contains '?' (triggering query-string escaping), "
-        "any numeric capture group reference ($1, $2, …) anywhere in that replacement "
-        "is subject to CVE-2026-42945 ('nginx rift') — a heap buffer overflow. "
-        "Whether the instance is exploitable depends on the nginx version and patch "
-        "status, which is not visible in the config. Switching to named capture groups "
-        "is the recommended mitigation and also improves readability."
+        "Using numeric capture groups ($1, $2, …) in a rewrite replacement that "
+        "contains a query string ('?') is associated with CVE-2026-42945. Whether "
+        "the instance is exploitable depends on the nginx version. Switching to named "
+        "capture groups is the recommended fix and also improves readability."
     )
     help_url = "https://gixy.io/plugins/unnamed_groups/"
     directives = ["rewrite"]

--- a/gixy/plugins/unnamed_groups.py
+++ b/gixy/plugins/unnamed_groups.py
@@ -6,27 +6,38 @@ from gixy.plugins.plugin import Plugin
 
 class unnamed_groups(Plugin):
     r"""
-    Detects rewrite directives that reference numeric capture groups ($1, $2, …)
-    in the query-string portion of the replacement URL — the pattern associated
-    with CVE-2026-42945 ("nginx rift").
+    Detects rewrite directives that combine a query string ('?') in the
+    replacement URL with numeric capture group references ($1, $2, …) anywhere
+    in that replacement — the pattern exploited by CVE-2026-42945 ("nginx rift").
+
+    The bug is a heap buffer overflow in ngx_http_rewrite_module: the length
+    calculation for capture group values uses the raw byte count, but the copy
+    applies NGX_ESCAPE_ARGS escaping (triggered by the presence of '?'), so
+    characters like '%', '+', and '&' expand from 1 to 3 bytes and overflow the
+    buffer. The overflow affects ALL $N references in the replacement, including
+    those that appear before the '?'.
 
     Whether any given nginx build is exploitable depends entirely on the nginx
     version and patch status, which cannot be determined from a config file.
     This finding is therefore informational: switching to named capture groups
     is the recommended fix and also improves readability independent of the CVE.
 
-    Flagged:
+    Flagged ($N after ?):
         rewrite ^/users/([0-9]+)/profile/(.*)$ /profile.php?id=$1&tab=$2 last;
 
-    Preferred:
+    Also flagged ($N before ?):
+        rewrite ^/(.*)$ /$1?v=2 last;
+
+    Preferred (named captures):
         rewrite ^/users/(?<id>[0-9]+)/profile/(?<tab>.*)$ /profile.php?id=$id&tab=$tab last;
     """
 
-    summary = "Numeric capture group reference in rewrite query string (CVE-2026-42945)."
+    summary = "Unnamed capture group reference in rewrite with query string (CVE-2026-42945)."
     severity = gixy.severity.INFORMATION
     description = (
-        "Referencing numeric capture groups ($1, $2, …) after a '?' in a rewrite "
-        "replacement is the pattern targeted by CVE-2026-42945 ('nginx rift'). "
+        "When a rewrite replacement contains '?' (triggering query-string escaping), "
+        "any numeric capture group reference ($1, $2, …) anywhere in that replacement "
+        "is subject to CVE-2026-42945 ('nginx rift') — a heap buffer overflow. "
         "Whether the instance is exploitable depends on the nginx version and patch "
         "status, which is not visible in the config. Switching to named capture groups "
         "is the recommended mitigation and also improves readability."
@@ -44,8 +55,7 @@ class unnamed_groups(Plugin):
         if "?" not in replacement:
             return
 
-        query_string = replacement.split("?", 1)[1]
-        capture_refs = self._CAPTURE_GROUP_REF.findall(query_string)
+        capture_refs = self._CAPTURE_GROUP_REF.findall(replacement)
         if not capture_refs:
             return
 
@@ -53,7 +63,7 @@ class unnamed_groups(Plugin):
         self.add_issue(
             directive=directive,
             reason=(
-                f"Rewrite target uses numeric capture group(s) {refs} in the query "
-                "string. See CVE-2026-42945."
+                f"Rewrite replacement contains '?' and references numeric capture "
+                f"group(s) {refs}. See CVE-2026-42945."
             ),
         )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
     - plugins/status_page_exposed.md
     - plugins/try_files_is_evil_too.md
     - plugins/unanchored_regex.md
+    - plugins/unnamed_groups.md
     - plugins/valid_referers.md
     - plugins/version_disclosure.md
     - plugins/worker_rlimit_nofile_vs_connections.md

--- a/tests/plugins/simply/unnamed_groups/config.json
+++ b/tests/plugins/simply/unnamed_groups/config.json
@@ -1,0 +1,3 @@
+{
+  "severity": "INFORMATION"
+}

--- a/tests/plugins/simply/unnamed_groups/unnamed_groups.conf
+++ b/tests/plugins/simply/unnamed_groups/unnamed_groups.conf
@@ -1,0 +1,5 @@
+server {
+    location / {
+        rewrite ^/users/([0-9]+)/profile/(.*)$ /profile.php?id=$1&tab=$2 last;
+    }
+}

--- a/tests/plugins/simply/unnamed_groups/unnamed_groups_fp.conf
+++ b/tests/plugins/simply/unnamed_groups/unnamed_groups_fp.conf
@@ -2,6 +2,6 @@ server {
     location / {
         rewrite ^/(.*)$ /$1?ok=1 last;
         rewrite ^/(.*)$ /profile/$1 last;
-        rewrite ^/users/(?<id>[0-9]+)$ /profile.php?id=$arg_id last;
+        rewrite ^/users/(?<id>[0-9]+)$ /profile.php?id=$id last;
     }
 }

--- a/tests/plugins/simply/unnamed_groups/unnamed_groups_fp.conf
+++ b/tests/plugins/simply/unnamed_groups/unnamed_groups_fp.conf
@@ -1,0 +1,7 @@
+server {
+    location / {
+        rewrite ^/(.*)$ /$1?ok=1 last;
+        rewrite ^/(.*)$ /profile/$1 last;
+        rewrite ^/users/(?<id>[0-9]+)$ /profile.php?id=$arg_id last;
+    }
+}

--- a/tests/plugins/simply/unnamed_groups/unnamed_groups_fp.conf
+++ b/tests/plugins/simply/unnamed_groups/unnamed_groups_fp.conf
@@ -1,7 +1,7 @@
 server {
     location / {
-        rewrite ^/(.*)$ /$1?ok=1 last;
         rewrite ^/(.*)$ /profile/$1 last;
         rewrite ^/users/(?<id>[0-9]+)$ /profile.php?id=$id last;
+        rewrite ^/(.*)$ /static?v=2 last;
     }
 }

--- a/tests/plugins/simply/unnamed_groups/unnamed_groups_path.conf
+++ b/tests/plugins/simply/unnamed_groups/unnamed_groups_path.conf
@@ -1,0 +1,5 @@
+server {
+    location / {
+        rewrite ^/(.*)$ /$1?v=2 last;
+    }
+}


### PR DESCRIPTION
Plugin should help people to detect any rewrite directives that could be vulnerable to [https://app.opencve.io/cve/CVE-2026-42945](CVE-2026-42945).

I've used a help url that doesn't exist, let me know if you'd rather change that.

`help_url = "https://gixy.io/plugins/unnamed_groups/"`