### PR TITLE
Fix variable scope: resolve set/map/geo vars regardless of source order

### DIFF
--- a/gixy/__init__.py
+++ b/gixy/__init__.py
@@ -2,4 +2,4 @@
 
 from gixy.core import severity
 
-version = "0.1.4"
+version = "0.1.5"

--- a/gixy/core/manager.py
+++ b/gixy/core/manager.py
@@ -6,8 +6,27 @@ from gixy.core import builtin_variables as builtins
 from gixy.core.config import Config
 from gixy.core.context import get_context, pop_context, purge_context, push_context
 from gixy.core.plugins_manager import PluginsManager
-from gixy.directives.directive import MapDirective
+from gixy.directives.block import GeoBlock, MapBlock
+from gixy.directives.directive import (
+    AuthRequestSetDirective,
+    MapDirective,
+    PerlSetDirective,
+    RootDirective,
+    SetByLuaDirective,
+    SetDirective,
+)
 from gixy.parser.nginx_parser import NginxParser
+
+# Directives that register a named variable visible throughout their enclosing
+# scope regardless of source order, matching nginx's parse-time registration.
+SCOPE_STATIC_VAR_PROVIDERS = (
+    SetDirective,
+    AuthRequestSetDirective,
+    PerlSetDirective,
+    SetByLuaDirective,
+    MapBlock,
+    GeoBlock,
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -63,6 +82,8 @@ class Manager(object):
         return stats
 
     def _audit_recursive(self, tree):
+        self._prepopulate_scope_var_names(tree)
+        self._prepopulate_scope_var_values(tree)
         for directive in tree:
             self._update_variables(directive)
             self.auditor.audit(directive)
@@ -72,6 +93,28 @@ class Manager(object):
                 self._audit_recursive(directive.children)
                 if directive.self_context:
                     pop_context()
+
+    def _prepopulate_scope_var_names(self, tree):
+        context = get_context()
+        for directive in tree:
+            if isinstance(directive, SCOPE_STATIC_VAR_PROVIDERS):
+                name = directive.variable
+                if name not in context.variables["name"]:
+                    context.add_var(name, builtins.fake_var(name))
+            elif isinstance(directive, RootDirective):
+                if "document_root" not in context.variables["name"]:
+                    context.add_var("document_root", builtins.fake_var("document_root"))
+            elif directive.is_block and not directive.self_context:
+                self._prepopulate_scope_var_names(directive.children)
+
+    def _prepopulate_scope_var_values(self, tree):
+        context = get_context()
+        for directive in tree:
+            if isinstance(directive, SCOPE_STATIC_VAR_PROVIDERS + (RootDirective,)):
+                for var in directive.variables:
+                    context.add_var(var.name, var)
+            elif directive.is_block and not directive.self_context:
+                self._prepopulate_scope_var_values(directive.children)
 
     def _update_variables(self, directive):
         # TODO(buglloc): finish him!

--- a/tests/core/test_manager.py
+++ b/tests/core/test_manager.py
@@ -1,0 +1,138 @@
+import io
+import logging
+
+from gixy.core.context import purge_context
+from gixy.core.manager import Manager
+
+
+def setup_function():
+    pass
+
+
+def teardown_function():
+    purge_context()
+
+
+def _audit(config, caplog=None):
+    if caplog is not None:
+        caplog.set_level(logging.INFO, logger='gixy.core.variable')
+    m = Manager()
+    m.audit('/tmp/inline.conf', io.StringIO(config), is_stdin=True)
+    return m
+
+
+def _missing(caplog):
+    return [
+        r for r in caplog.records
+        if r.name == 'gixy.core.variable' and "Can't find variable" in r.getMessage()
+    ]
+
+
+def test_set_after_location_is_visible(caplog):
+    _audit("""
+http { server {
+    location @err { root $Root_Path/pages; }
+    set $Root_Path /var/www;
+} }
+""", caplog)
+    assert _missing(caplog) == []
+
+
+def test_map_after_server_is_visible(caplog):
+    _audit("""
+http {
+    server {
+        location = /.well-known/security.txt {
+            return 200 "Canonical: https://$canonical_host/security.txt";
+        }
+    }
+    map $ssl_server_name $canonical_host {
+        default $ssl_server_name;
+    }
+}
+""", caplog)
+    assert _missing(caplog) == []
+
+
+def test_geo_after_server_is_visible(caplog):
+    _audit("""
+http {
+    server {
+        location / { return 200 $country_code; }
+    }
+    geo $country_code {
+        default ZZ;
+        192.168.1.0/24 US;
+    }
+}
+""", caplog)
+    assert _missing(caplog) == []
+
+
+
+def test_set_in_if_block_is_visible_to_sibling_location(caplog):
+    _audit("""
+http { server {
+    location / { return 200 $mode; }
+    if ($request_method = POST) { set $mode write; }
+} }
+""", caplog)
+    assert _missing(caplog) == []
+
+
+def test_chained_set_forward_ref_does_not_log(caplog):
+    _audit("""
+http { server {
+    set $X "$Y/sub";
+    set $Y /base;
+    location / { return 200 $X; }
+} }
+""", caplog)
+    assert _missing(caplog) == []
+
+
+def test_map_status_to_error_code_after_server_is_visible(caplog):
+    # Reproduces issue #105: $error_code defined via map $status after the server block
+    _audit("""
+http {
+    server {
+        location = /50x.html {
+            return 200 "Error: $error_code - $request_id";
+        }
+    }
+    map $status $error_code {
+        default      "Internal Server Error";
+        400          "Bad Request";
+        401          "Unauthorized";
+        403          "Forbidden";
+        404          "Not Found";
+    }
+}
+""", caplog)
+    assert _missing(caplog) == []
+
+
+def test_set_in_one_location_does_not_leak_to_sibling(caplog):
+    _audit("""
+http { server {
+    location /a { set $LocalOnly x; }
+    location /b { return 200 $LocalOnly; }
+} }
+""", caplog)
+    assert any('LocalOnly' in r.getMessage() for r in _missing(caplog))
+
+
+def test_prepopulated_map_taint_still_fires_security_check():
+    # map-after-server routes tainted $uri through $target; http_splitting must still fire
+    config = """
+http {
+    server {
+        location / { return 301 http://$target; }
+    }
+    map $uri $target {
+        default $uri;
+    }
+}
+"""
+    m = _audit(config)
+    assert any(type(p).__name__ == 'http_splitting' for p in m.results)

--- a/tests/plugins/simply/http_splitting/return_with_map_after_server_fp.conf
+++ b/tests/plugins/simply/http_splitting/return_with_map_after_server_fp.conf
@@ -1,0 +1,10 @@
+server {
+    location = /.well-known/security.txt {
+        default_type text/plain;
+        return 200 "Canonical: https://$canonical_host/.well-known/security.txt";
+    }
+}
+
+map $ssl_server_name $canonical_host {
+    default $ssl_server_name;
+}


### PR DESCRIPTION
Nginx registers set/map/geo variables at parse time regardless of declaration order. Gixy was resolving them sequentially, so variables declared after their referencing block were invisible causing false "Can't find variable" warnings and missed security issues.
