### PR TITLE
Add quic_bpf_reuseport plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Gixy-Next can detect a wide range of NGINX security and performance misconfigura
 *   [[origins] Problems with referer/origin header validation](https://gixy.io/plugins/origins/)
 *   [[proxy_buffering_off] Disabling `proxy_buffering`](https://gixy.io/plugins/proxy_buffering_off/)
 *   [[proxy_pass_normalized] `proxy_pass` path normalization issues](https://gixy.io/plugins/proxy_pass_normalized/)
+*   [[quic_bpf_reuseport] QUIC connections silently dropped after reload](https://gixy.io/plugins/quic_bpf_reuseport/)
 *   [[regex_redos] Regular expression denial of service (ReDoS)](https://gixy.io/plugins/regex_redos/)
 *   [[resolver_external] Using external DNS nameservers](https://gixy.io/plugins/resolver_external/)
 *   [[return_bypasses_allow_deny] Return directive bypasses allow/deny restrictions](https://gixy.io/plugins/return_bypasses_allow_deny/)

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -99,6 +99,7 @@ Gixy-Next can detect a wide range of NGINX security and performance misconfigura
 *   [[origins] Problems with referer/origin header validation](https://gixy.io/plugins/origins/)
 *   [[proxy_buffering_off] Disabling `proxy_buffering`](https://gixy.io/plugins/proxy_buffering_off/)
 *   [[proxy_pass_normalized] `proxy_pass` path normalization issues](https://gixy.io/plugins/proxy_pass_normalized/)
+*   [[quic_bpf_reuseport] QUIC connections silently dropped after reload](https://gixy.io/plugins/quic_bpf_reuseport/)
 *   [[regex_redos] Regular expression denial of service (ReDoS)](https://gixy.io/plugins/regex_redos/)
 *   [[resolver_external] Using external DNS nameservers](https://gixy.io/plugins/resolver_external/)
 *   [[return_bypasses_allow_deny] Return directive bypasses allow/deny restrictions](https://gixy.io/plugins/return_bypasses_allow_deny/)

--- a/docs/en/plugins/quic_bpf_reuseport.md
+++ b/docs/en/plugins/quic_bpf_reuseport.md
@@ -1,0 +1,58 @@
+---
+title: "QUIC BPF Reuseport"
+description: "Detects the quic_bpf + reuseport + multiple workers combination that silently drops ~50% of QUIC connections after every nginx reload."
+---
+
+# [quic_bpf_reuseport] QUIC connections silently dropped after reload
+
+## What this check looks for
+
+This plugin flags configurations where all three of the following are present simultaneously:
+
+* `quic_bpf on;` in the main context
+* `reuseport` on a QUIC listen socket
+* `worker_processes` greater than 1 (or `auto`)
+
+## Why this is a problem
+
+When these conditions coincide, NGINX silently drops approximately 50% of QUIC connections after every `nginx -s reload`. The root cause is stale BPF reuseport maps: after a reload, old worker processes hold BPF maps that reference socket file descriptors which no longer exist in the new workers, so roughly half of incoming QUIC packets are sent to the wrong worker and silently discarded.
+
+This is a known upstream NGINX bug ([nginx/nginx#425](https://github.com/nginx/nginx/issues/425)) that remains unfixed in mainline.
+
+## Bad configuration
+
+```nginx
+worker_processes auto;
+quic_bpf on;
+
+http {
+    server {
+        listen 443 quic reuseport;
+        listen 443 ssl;
+        server_name example.com;
+    }
+}
+```
+
+## Better configuration
+
+Disable `quic_bpf`:
+
+```nginx
+worker_processes auto;
+quic_bpf off;
+
+http {
+    server {
+        listen 443 quic reuseport;
+        listen 443 ssl;
+        server_name example.com;
+    }
+}
+```
+
+## Additional notes
+
+* The bug does not trigger with `worker_processes 1` since there is only one worker and no BPF map handoff occurs.
+* If `worker_processes` is not set, NGINX defaults to 1, which is also safe.
+* Removing `reuseport` from the QUIC listener also avoids the bug, though at the cost of reduced multi-core performance.

--- a/gixy/__init__.py
+++ b/gixy/__init__.py
@@ -2,4 +2,4 @@
 
 from gixy.core import severity
 
-version = "0.1.4"
+version = "0.1.6"

--- a/gixy/plugins/quic_bpf_reuseport.py
+++ b/gixy/plugins/quic_bpf_reuseport.py
@@ -1,0 +1,49 @@
+import gixy
+from gixy.plugins.plugin import Plugin
+
+
+class quic_bpf_reuseport(Plugin):
+    """Flag quic_bpf + reuseport + multi-worker combinations that silently drop QUIC connections after reload."""
+
+    summary = "quic_bpf with reuseport and multiple workers silently drops QUIC connections after reload."
+    severity = gixy.severity.HIGH
+    description = (
+        "When quic_bpf is enabled alongside reuseport on a QUIC listen socket "
+        "and multiple worker processes, NGINX silently drops ~50% of QUIC connections "
+        "after every reload due to stale BPF reuseport maps (nginx/nginx#425). "
+        "Disable quic_bpf to resolve this."
+    )
+    help_url = "https://gixy.io/plugins/quic_bpf_reuseport/"
+    directives = []
+    supports_full_config = True
+
+    def audit(self, directive):
+        return
+
+    def post_audit(self, root):
+        quic_bpf = root.some("quic_bpf")
+        if not quic_bpf or not quic_bpf.args or quic_bpf.args[0] != "on":
+            return
+
+        worker_procs = root.some("worker_processes")
+        if not worker_procs or not worker_procs.args:
+            return
+        if worker_procs.args[0] == "1":
+            return
+
+        http_block = root.some("http", flat=False)
+        if not http_block:
+            return
+
+        for server in http_block.find_all_contexts_of_type("server"):
+            for listen in server.find("listen"):
+                tokens = [t.lower() for t in listen.args]
+                if "quic" in tokens and "reuseport" in tokens:
+                    self.add_issue(
+                        directive=quic_bpf,
+                        reason=(
+                            "quic_bpf on with reuseport on a QUIC listener and multiple workers "
+                            "causes ~50% QUIC connection drops after reload (nginx/nginx#425)."
+                        ),
+                    )
+                    return

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
     - plugins/origins.md
     - plugins/proxy_buffering_off.md
     - plugins/proxy_pass_normalized.md
+    - plugins/quic_bpf_reuseport.md
     - plugins/regex_redos.md
     - plugins/resolver_external.md
     - plugins/return_bypasses_allow_deny.md

--- a/tests/plugins/simply/quic_bpf_reuseport/quic_bpf_reuseport.conf
+++ b/tests/plugins/simply/quic_bpf_reuseport/quic_bpf_reuseport.conf
@@ -1,0 +1,10 @@
+worker_processes auto;
+quic_bpf on;
+
+http {
+    server {
+        listen 443 quic reuseport;
+        listen 443 ssl;
+        server_name example.com;
+    }
+}

--- a/tests/plugins/simply/quic_bpf_reuseport/quic_bpf_reuseport_explicit_workers.conf
+++ b/tests/plugins/simply/quic_bpf_reuseport/quic_bpf_reuseport_explicit_workers.conf
@@ -1,0 +1,10 @@
+worker_processes 4;
+quic_bpf on;
+
+http {
+    server {
+        listen 443 quic reuseport;
+        listen 443 ssl;
+        server_name example.com;
+    }
+}

--- a/tests/plugins/simply/quic_bpf_reuseport/quic_bpf_reuseport_fp.conf
+++ b/tests/plugins/simply/quic_bpf_reuseport/quic_bpf_reuseport_fp.conf
@@ -1,0 +1,10 @@
+worker_processes auto;
+quic_bpf off;
+
+http {
+    server {
+        listen 443 quic reuseport;
+        listen 443 ssl;
+        server_name example.com;
+    }
+}

--- a/tests/plugins/simply/quic_bpf_reuseport/quic_bpf_reuseport_no_reuseport_fp.conf
+++ b/tests/plugins/simply/quic_bpf_reuseport/quic_bpf_reuseport_no_reuseport_fp.conf
@@ -1,0 +1,10 @@
+worker_processes auto;
+quic_bpf on;
+
+http {
+    server {
+        listen 443 quic;
+        listen 443 ssl;
+        server_name example.com;
+    }
+}

--- a/tests/plugins/simply/quic_bpf_reuseport/quic_bpf_reuseport_no_wp_fp.conf
+++ b/tests/plugins/simply/quic_bpf_reuseport/quic_bpf_reuseport_no_wp_fp.conf
@@ -1,0 +1,9 @@
+quic_bpf on;
+
+http {
+    server {
+        listen 443 quic reuseport;
+        listen 443 ssl;
+        server_name example.com;
+    }
+}

--- a/tests/plugins/simply/quic_bpf_reuseport/quic_bpf_reuseport_single_worker_fp.conf
+++ b/tests/plugins/simply/quic_bpf_reuseport/quic_bpf_reuseport_single_worker_fp.conf
@@ -1,0 +1,10 @@
+worker_processes 1;
+quic_bpf on;
+
+http {
+    server {
+        listen 443 quic reuseport;
+        listen 443 ssl;
+        server_name example.com;
+    }
+}


### PR DESCRIPTION
Detects the combination of quic_bpf on, reuseport on a QUIC listen socket, and worker_processes > 1 that silently drops ~50% of QUIC connections after every nginx -s reload (nginx/nginx#425).