### PR TITLE
Add http2_misdirected_request plugin: detect missing 421 safeguard on…

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Gixy-Next can detect a wide range of NGINX security and performance misconfigura
 *   [[error_log_off] `error_log` set to `off`](https://gixy.io/plugins/error_log_off/)
 *   [[hash_without_default] Missing default in hash blocks](https://gixy.io/plugins/hash_without_default/)
 *   [[host_spoofing] Request's Host header forgery](https://gixy.io/plugins/host_spoofing/)
+*   [[http2_misdirected_request] Missing HTTP/2 misdirected-request safeguard](https://gixy.io/plugins/http2_misdirected_request/)
 *   [[http_splitting] HTTP Response Splitting](https://gixy.io/plugins/http_splitting/)
 *   [[if_is_evil] If is evil when used in location context](https://gixy.io/plugins/if_is_evil/)
 *   [[invalid_regex] Invalid regex capture groups](https://gixy.io/plugins/invalid_regex/)

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -90,6 +90,7 @@ Gixy-Next can detect a wide range of NGINX security and performance misconfigura
 *   [[error_log_off] `error_log` set to `off`](https://gixy.io/plugins/error_log_off/)
 *   [[hash_without_default] Missing default in hash blocks](https://gixy.io/plugins/hash_without_default/)
 *   [[host_spoofing] Request's Host header forgery](https://gixy.io/plugins/host_spoofing/)
+*   [[http2_misdirected_request] Missing HTTP/2 misdirected-request safeguard](https://gixy.io/plugins/http2_misdirected_request/)
 *   [[http_splitting] HTTP Response Splitting](https://gixy.io/plugins/http_splitting/)
 *   [[if_is_evil] If is evil when used in location context](https://gixy.io/plugins/if_is_evil/)
 *   [[invalid_regex] Invalid regex capture groups](https://gixy.io/plugins/invalid_regex/)

--- a/docs/en/plugins/http2_misdirected_request.md
+++ b/docs/en/plugins/http2_misdirected_request.md
@@ -1,0 +1,55 @@
+---
+title: "HTTP/2 Misdirected Request"
+description: "Detects TLS default_server blocks with ssl_reject_handshake and HTTP/2 enabled that are missing a location / { return 421; } safeguard against misdirected HTTP/2 requests."
+---
+
+# [http2_misdirected_request] Missing HTTP/2 misdirected-request safeguard
+
+## What this check looks for
+
+This plugin flags `server` blocks where all of the following are true:
+
+* `ssl_reject_handshake on;` is present
+* the server is marked `default_server` (or `default`) on a `listen` directive
+* HTTP/2 is enabled (via `http2 on;` or `listen ... http2;`)
+* there is no `location /` or `location = /` that returns 421
+
+## Why this is a problem
+
+HTTP/2 allows connection reuse: a client may reuse an existing TLS connection to send a request for a different server name. When `ssl_reject_handshake on` is used on a `default_server` to block unknown SNI names at the TLS level, this does not fully cover the HTTP/2 reuse case — some requests can still reach the server context at the HTTP layer.
+
+RFC 7540 §9.1.2 defines status code 421 (Misdirected Request) for exactly this situation. Returning 421 from `location /` gives clients an unambiguous, spec-compliant response and prevents the default server from inadvertently handling requests intended for another host.
+
+## Bad configuration
+
+```nginx
+http {
+    server {
+        listen 443 ssl default_server;
+        http2 on;
+        ssl_reject_handshake on;
+        # no location / returning 421 — misdirected HTTP/2 requests get no explicit rejection
+    }
+}
+```
+
+## Better configuration
+
+```nginx
+http {
+    server {
+        listen 443 ssl default_server;
+        http2 on;
+        ssl_reject_handshake on;
+        location / {
+            return 421;
+        }
+    }
+}
+```
+
+## Additional notes
+
+* Both the modern `http2 on;` directive (NGINX 1.25.1+) and the older `listen ... http2;` syntax are recognised.
+* `location = / { return 421; }` (exact match) is also accepted as a valid safeguard.
+* This check only applies when `ssl_reject_handshake on` is explicitly set; without it the pattern is not in use and the check does not fire.

--- a/gixy/plugins/http2_misdirected_request.py
+++ b/gixy/plugins/http2_misdirected_request.py
@@ -1,0 +1,69 @@
+import gixy
+from gixy.plugins.plugin import Plugin
+
+
+class http2_misdirected_request(Plugin):
+    """Flag TLS default_server blocks with ssl_reject_handshake and HTTP/2 that lack a location / returning 421."""
+
+    summary = "Missing HTTP/2 misdirected-request safeguard (return 421)."
+    severity = gixy.severity.LOW
+    description = (
+        "With HTTP/2 enabled, connection reuse may cause requests to reach a TLS default_server "
+        "even when ssl_reject_handshake is set. A location / { return 421; } provides a "
+        "deterministic, spec-compliant rejection of those misdirected requests."
+    )
+    help_url = "https://gixy.io/plugins/http2_misdirected_request/"
+    directives = []
+    supports_full_config = True
+
+    def audit(self, directive):
+        return
+
+    def post_audit(self, root):
+        http_block = root.some("http", flat=False)
+        if not http_block:
+            return
+
+        http2_dir = http_block.some("http2")
+        http2_global = bool(http2_dir and http2_dir.args and http2_dir.args[0] == "on")
+
+        for server in http_block.find_all_contexts_of_type("server"):
+            ssl_reject = server.some("ssl_reject_handshake")
+            if not ssl_reject or not ssl_reject.args or ssl_reject.args[0] != "on":
+                continue
+            if not self._server_is_default(server):
+                continue
+            if not http2_global and not self._server_has_http2(server):
+                continue
+            if self._has_location_returning_421(server):
+                continue
+            self.add_issue(
+                directive=ssl_reject,
+                reason=(
+                    "default_server with ssl_reject_handshake on and HTTP/2 enabled "
+                    "should define location / { return 421; } to reject misdirected HTTP/2 requests."
+                ),
+            )
+
+    def _server_is_default(self, server):
+        for listen in server.find("listen"):
+            if any(t.lower() in ("default_server", "default") for t in listen.args):
+                return True
+        return False
+
+    def _server_has_http2(self, server):
+        http2 = server.some("http2")
+        if http2 and http2.args and http2.args[0] == "on":
+            return True
+        for listen in server.find("listen"):
+            if any(t.lower() == "http2" for t in listen.args):
+                return True
+        return False
+
+    def _has_location_returning_421(self, server):
+        for location in server.find("location", flat=True):
+            if location.path != "/":
+                continue
+            if any(r.args and r.args[0] == "421" for r in location.find("return")):
+                return True
+        return False

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
     - plugins/error_log_off.md
     - plugins/hash_without_default.md
     - plugins/host_spoofing.md
+    - plugins/http2_misdirected_request.md
     - plugins/http_splitting.md
     - plugins/if_is_evil.md
     - plugins/invalid_regex.md

--- a/tests/plugins/simply/http2_misdirected_request/http2_misdirected_request.conf
+++ b/tests/plugins/simply/http2_misdirected_request/http2_misdirected_request.conf
@@ -1,0 +1,7 @@
+http {
+    server {
+        listen 443 ssl default_server;
+        http2 on;
+        ssl_reject_handshake on;
+    }
+}

--- a/tests/plugins/simply/http2_misdirected_request/http2_misdirected_request_exact_location_fp.conf
+++ b/tests/plugins/simply/http2_misdirected_request/http2_misdirected_request_exact_location_fp.conf
@@ -1,0 +1,10 @@
+http {
+    server {
+        listen 443 ssl default_server;
+        http2 on;
+        ssl_reject_handshake on;
+        location = / {
+            return 421;
+        }
+    }
+}

--- a/tests/plugins/simply/http2_misdirected_request/http2_misdirected_request_fp.conf
+++ b/tests/plugins/simply/http2_misdirected_request/http2_misdirected_request_fp.conf
@@ -1,0 +1,10 @@
+http {
+    server {
+        listen 443 ssl default_server;
+        http2 on;
+        ssl_reject_handshake on;
+        location / {
+            return 421;
+        }
+    }
+}

--- a/tests/plugins/simply/http2_misdirected_request/http2_misdirected_request_global_http2.conf
+++ b/tests/plugins/simply/http2_misdirected_request/http2_misdirected_request_global_http2.conf
@@ -1,0 +1,7 @@
+http {
+    http2 on;
+    server {
+        listen 443 ssl default_server;
+        ssl_reject_handshake on;
+    }
+}

--- a/tests/plugins/simply/http2_misdirected_request/http2_misdirected_request_listen_http2.conf
+++ b/tests/plugins/simply/http2_misdirected_request/http2_misdirected_request_listen_http2.conf
@@ -1,0 +1,6 @@
+http {
+    server {
+        listen 443 ssl http2 default_server;
+        ssl_reject_handshake on;
+    }
+}

--- a/tests/plugins/simply/http2_misdirected_request/http2_misdirected_request_nested_location.conf
+++ b/tests/plugins/simply/http2_misdirected_request/http2_misdirected_request_nested_location.conf
@@ -1,0 +1,12 @@
+http {
+    server {
+        listen 443 ssl default_server;
+        http2 on;
+        ssl_reject_handshake on;
+        location /sub {
+            location / {
+                return 421;
+            }
+        }
+    }
+}

--- a/tests/plugins/simply/http2_misdirected_request/http2_misdirected_request_no_default_fp.conf
+++ b/tests/plugins/simply/http2_misdirected_request/http2_misdirected_request_no_default_fp.conf
@@ -1,0 +1,7 @@
+http {
+    server {
+        listen 443 ssl;
+        http2 on;
+        ssl_reject_handshake on;
+    }
+}

--- a/tests/plugins/simply/http2_misdirected_request/http2_misdirected_request_no_http2_fp.conf
+++ b/tests/plugins/simply/http2_misdirected_request/http2_misdirected_request_no_http2_fp.conf
@@ -1,0 +1,6 @@
+http {
+    server {
+        listen 443 ssl default_server;
+        ssl_reject_handshake on;
+    }
+}

--- a/tests/plugins/simply/http2_misdirected_request/http2_misdirected_request_no_reject_fp.conf
+++ b/tests/plugins/simply/http2_misdirected_request/http2_misdirected_request_no_reject_fp.conf
@@ -1,0 +1,6 @@
+http {
+    server {
+        listen 443 ssl default_server;
+        http2 on;
+    }
+}


### PR DESCRIPTION
Detects TLS default_server blocks that have ssl_reject_handshake on and HTTP/2 enabled but are missing a `location / { return 421; }` safeguard. HTTP/2 connection reuse can deliver requests to such a server at the HTTP layer even after TLS handshake rejection; returning 421 is the spec-compliant response per RFC 7540 §9.1.2.
