### PR TITLE
Fix/bug hunt findings

### DIFF
--- a/gixy/plugins/invalid_regex.py
+++ b/gixy/plugins/invalid_regex.py
@@ -110,14 +110,14 @@ class invalid_regex(Plugin):
             return
 
         operator = if_directive.args[1]
-        if operator not in ["~", "~*"]:
+        if operator not in ["~", "~*", "!~", "!~*"]:
             return
 
         pattern = if_directive.args[2]
 
         # Parse the regex to determine available groups
         try:
-            regexp = Regexp(pattern, case_sensitive=(operator == "~"))
+            regexp = Regexp(pattern, case_sensitive=(operator in ["~", "!~"]))
             available_groups = set(regexp.groups.keys())
             available_groups.discard(0)
         except Exception:

--- a/gixy/plugins/origins.py
+++ b/gixy/plugins/origins.py
@@ -185,7 +185,7 @@ class origins(Plugin):
             suffix_mutant_raw_filled = suffix_mutant_raw.replace("`", "b")
             prefix_mutant_raw_filled = prefix_mutant_raw.replace("`", "c")
 
-            if not self.same_origin(base_hostname_filled, base_hostname_filled):
+            if not self.same_origin(base_hostname, base_hostname_filled):
                 self.insecure_set.add(base_mutant_raw_filled)
                 continue
 

--- a/gixy/plugins/status_page_exposed.py
+++ b/gixy/plugins/status_page_exposed.py
@@ -12,7 +12,7 @@ class status_page_exposed(Plugin):
         "If not IP-restricted, it is accessible to anyone and useful for reconnaissance."
     )
     directives = ["stub_status"]
-    help_url = "https://gixy.io/plugins/stale_dns_cache/"
+    help_url = "https://gixy.io/plugins/status_page_exposed/"
 
     def _server_uses_only_unix_sockets(self, directive):
         """True if the enclosing server listens only on unix: sockets."""

--- a/tests/plugins/simply/invalid_regex/if_negative_match_fp.conf
+++ b/tests/plugins/simply/invalid_regex/if_negative_match_fp.conf
@@ -1,0 +1,7 @@
+server {
+    location / {
+        if ($uri !~ "^/([a-z]+)") {
+            set $x $1;
+        }
+    }
+}

--- a/tests/plugins/simply/invalid_regex/if_negative_match_icase_wrong_group.conf
+++ b/tests/plugins/simply/invalid_regex/if_negative_match_icase_wrong_group.conf
@@ -1,0 +1,7 @@
+server {
+    location / {
+        if ($uri !~* "^/([a-z]+)") {
+            set $x $2;
+        }
+    }
+}

--- a/tests/plugins/simply/invalid_regex/if_negative_match_wrong_group.conf
+++ b/tests/plugins/simply/invalid_regex/if_negative_match_wrong_group.conf
@@ -1,0 +1,7 @@
+server {
+    location / {
+        if ($uri !~ "^/([a-z]+)") {
+            set $x $2;
+        }
+    }
+}


### PR DESCRIPTION
- `status_page_exposed`: `help_url` pointed to `stale_dns_cache` (copy-paste typo)
- `origins`: `same_origin(base_hostname_filled, base_hostname_filled)` compared a value to itself — dead code; fix compares `base_hostname` against `base_hostname_filled` to detect wildcard positions that cross a domain boundary 
  - `invalid_regex`: `!~` and `!~*` operators were excluded from capture-group reference validation, causing false negatives when a `set` directive inside a negative `if` block referenced a non-existent group; also fixes `case_sensitive` logic (`!~` is case-sensitive like `~`, not case-insensitive)
