### PR TITLE
Add mixed_case_variable plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Gixy-Next can detect a wide range of NGINX security and performance misconfigura
 *   [[invalid_regex] Invalid regex capture groups](https://gixy.io/plugins/invalid_regex/)
 *   [[low_keepalive_requests] Low `keepalive_requests`](https://gixy.io/plugins/low_keepalive_requests/)
 *   [[merge_slashes_on] Enabling merge_slashes](https://gixy.io/plugins/merge_slashes_on/)
+*   [[mixed_case_variable] Mixed-case variable references](https://gixy.io/plugins/mixed_case_variable/)
 *   [[missing_worker_processes] Missing `worker_processes`](https://gixy.io/plugins/missing_worker_processes/)
 *   [[origins] Problems with referer/origin header validation](https://gixy.io/plugins/origins/)
 *   [[proxy_buffering_off] Disabling `proxy_buffering`](https://gixy.io/plugins/proxy_buffering_off/)

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -96,6 +96,7 @@ Gixy-Next can detect a wide range of NGINX security and performance misconfigura
 *   [[invalid_regex] Invalid regex capture groups](https://gixy.io/plugins/invalid_regex/)
 *   [[low_keepalive_requests] Low `keepalive_requests`](https://gixy.io/plugins/low_keepalive_requests/)
 *   [[merge_slashes_on] Enabling merge_slashes](https://gixy.io/plugins/merge_slashes_on/)
+*   [[mixed_case_variable] Mixed-case variable references](https://gixy.io/plugins/mixed_case_variable/)
 *   [[missing_worker_processes] Missing `worker_processes`](https://gixy.io/plugins/missing_worker_processes/)
 *   [[origins] Problems with referer/origin header validation](https://gixy.io/plugins/origins/)
 *   [[proxy_buffering_off] Disabling `proxy_buffering`](https://gixy.io/plugins/proxy_buffering_off/)

--- a/docs/en/plugins/mixed_case_variable.md
+++ b/docs/en/plugins/mixed_case_variable.md
@@ -1,0 +1,64 @@
+---
+title: "Mixed-case variable references"
+description: "Detects when the same NGINX variable is referenced with inconsistent casing within one config. NGINX normalizes all variable names to lowercase, so $My_Var and $MY_VAR are identical — mixing spellings looks like two distinct variables and likely indicates a typo."
+---
+
+# [mixed_case_variable] Mixed-case variable references
+
+## What this check looks for
+
+This plugin flags configurations where the same NGINX variable is referenced using more than one casing within the same config — for example, `$My_Var` in one directive and `$MY_VAR` in another.
+
+## Why this is a problem
+
+NGINX normalizes all variable names to lowercase at parse time. `$My_Var`, `$my_var`, and `$MY_VAR` all refer to the same variable. When the same variable appears with different capitalizations in one config, it looks like two distinct variables. This is misleading and almost always indicates a typo — one of the spellings may have been intended to refer to a different variable entirely.
+
+## Bad configuration
+
+```nginx
+server {
+    location / {
+        set $My_Var "hello";
+        proxy_pass http://backend/$MY_VAR;
+    }
+}
+```
+
+`$My_Var` and `$MY_VAR` are the same variable; the inconsistency suggests a copy-paste error.
+
+A more subtle case involving conditional logic:
+
+```nginx
+server {
+    set $jwt_token "";
+
+    if ($http_authorization ~ "^Bearer (.+)$") {
+        set $JWT_Token $1;
+    }
+
+    if ($jwt_token = "") {
+        return 401 "Unauthorized";
+    }
+
+    proxy_set_header X-JWT-Token $jwt_token;
+}
+```
+
+`$jwt_token` is initialized and checked as lowercase, but assigned in the `if` block as `$JWT_Token`. The second `if` condition and the `proxy_set_header` directive will always see the value set by the first `set $jwt_token ""` line, never the one from the `if` block.
+
+## Better configuration
+
+Use a consistent, lowercase name throughout:
+
+```nginx
+server {
+    location / {
+        set $my_var "hello";
+        proxy_pass http://backend/$my_var;
+    }
+}
+```
+
+## Additional notes
+
+This applies to all NGINX variables regardless of origin: user-defined (`set`), built-in (`$http_*`, `$arg_*`, etc.), and variables produced by `map`, `geo`, `rewrite`, and regex capture groups. Named regex capture groups (`(?P<Name>...)`) are also normalized to lowercase by NGINX, so `$Name` and `$name` are the same variable.

--- a/gixy/plugins/mixed_case_variable.py
+++ b/gixy/plugins/mixed_case_variable.py
@@ -28,7 +28,7 @@ class mixed_case_variable(Plugin):
         "is misleading and may indicate a typo."
     )
     help_url = "https://gixy.io/plugins/mixed_case_variable/"
-    directives = []  # empty → receives every directive
+    directives = []
 
     def __init__(self, config):
         super().__init__(config)

--- a/gixy/plugins/mixed_case_variable.py
+++ b/gixy/plugins/mixed_case_variable.py
@@ -1,0 +1,63 @@
+import re
+
+import gixy
+from gixy.plugins.plugin import Plugin
+
+_VAR_RE = re.compile(r"\$([a-z_][a-z0-9_]*|\{[a-z_][a-z0-9_]*\})", re.IGNORECASE)
+
+
+class mixed_case_variable(Plugin):
+    """
+    Detects when the same NGINX variable is referenced with different cases
+    within the same config.
+
+    Since NGINX normalizes all variable names to lowercase, $My_Var and
+    $MY_VAR are the same variable. Using both spellings in one config looks
+    like two distinct variables and suggests a typo or oversight.
+
+    Example:
+        set $My_Var "hello";
+        proxy_pass http://backend/$MY_VAR;  # same variable, different case
+    """
+
+    summary = "Same variable referenced with inconsistent case."
+    severity = gixy.severity.LOW
+    description = (
+        "NGINX normalizes all variable names to lowercase. "
+        "Referencing the same variable with different cases in one config "
+        "is misleading and may indicate a typo."
+    )
+    help_url = "https://gixy.io/plugins/mixed_case_variable/"
+    directives = []  # empty → receives every directive
+
+    def __init__(self, config):
+        super().__init__(config)
+        # lowercase_name -> {original_case: first directive that used it}
+        self._seen = {}
+        self._finalized = False
+
+    def audit(self, directive):
+        for arg in directive.args:
+            for m in _VAR_RE.finditer(arg):
+                name = m.group(1).strip("{}")
+                entry = self._seen.setdefault(name.lower(), {})
+                entry.setdefault(name, directive)
+
+    def _finalize(self):
+        if self._finalized:
+            return
+        self._finalized = True
+        for lower_name, cases in self._seen.items():
+            if len(cases) <= 1:
+                continue
+            forms = sorted(cases)
+            forms_str = ", ".join(f"`${f}`" for f in forms)
+            self.add_issue(
+                directive=[cases[f] for f in forms],
+                reason=f"`${lower_name}` is used with inconsistent casing: {forms_str}.",
+            )
+
+    @property
+    def issues(self):
+        self._finalize()
+        return self._issues

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
     - plugins/invalid_regex.md
     - plugins/low_keepalive_requests.md
     - plugins/merge_slashes_on.md
+    - plugins/mixed_case_variable.md
     - plugins/missing_worker_processes.md
     - plugins/origins.md
     - plugins/proxy_buffering_off.md

--- a/tests/plugins/simply/mixed_case_variable/auth_proxy_full_fp.conf
+++ b/tests/plugins/simply/mixed_case_variable/auth_proxy_full_fp.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    server_name app.example.com;
+
+    set $auth_status "";
+    set $cache_bypass "0";
+
+    location / {
+        if ($http_authorization ~ "^Bearer ") {
+            set $auth_status "authenticated";
+            set $cache_bypass "1";
+        }
+
+        if ($http_cookie ~ "session=") {
+            set $auth_status "session";
+            set $cache_bypass "1";
+        }
+
+        proxy_cache_bypass $cache_bypass;
+        proxy_no_cache $cache_bypass;
+        proxy_set_header X-Auth-Status $auth_status;
+        proxy_set_header Authorization $http_authorization;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_pass http://app_backend;
+    }
+}

--- a/tests/plugins/simply/mixed_case_variable/backend_selection_mixed_case.conf
+++ b/tests/plugins/simply/mixed_case_variable/backend_selection_mixed_case.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    server_name example.com;
+
+    set $Target_Backend "us-east.internal";
+
+    if ($http_x_region = "eu") {
+        set $target_backend "eu-west.internal";
+    }
+
+    if ($http_x_region = "ap") {
+        set $target_backend "ap-southeast.internal";
+    }
+
+    location / {
+        proxy_pass http://$Target_Backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}

--- a/tests/plugins/simply/mixed_case_variable/config.json
+++ b/tests/plugins/simply/mixed_case_variable/config.json
@@ -1,0 +1,3 @@
+{
+  "severity": "LOW"
+}

--- a/tests/plugins/simply/mixed_case_variable/consistent_lowercase_fp.conf
+++ b/tests/plugins/simply/mixed_case_variable/consistent_lowercase_fp.conf
@@ -1,0 +1,6 @@
+server {
+    location / {
+        set $my_var "hello";
+        proxy_pass http://backend/$my_var;
+    }
+}

--- a/tests/plugins/simply/mixed_case_variable/consistent_uppercase_fp.conf
+++ b/tests/plugins/simply/mixed_case_variable/consistent_uppercase_fp.conf
@@ -1,0 +1,6 @@
+server {
+    location / {
+        set $MY_VAR "hello";
+        proxy_pass http://backend/$MY_VAR;
+    }
+}

--- a/tests/plugins/simply/mixed_case_variable/cors_full_config_fp.conf
+++ b/tests/plugins/simply/mixed_case_variable/cors_full_config_fp.conf
@@ -1,0 +1,27 @@
+http {
+    map $http_origin $cors_origin {
+        ~^https://(www\.)?example\.com$ $http_origin;
+        default "";
+    }
+
+    server {
+        listen 443 ssl;
+        server_name api.example.com;
+
+        location /api {
+            set $cors_methods "GET, POST, PUT, DELETE, OPTIONS";
+
+            if ($request_method = OPTIONS) {
+                add_header Access-Control-Allow-Origin $cors_origin;
+                add_header Access-Control-Allow-Methods $cors_methods;
+                add_header Access-Control-Max-Age 3600;
+                return 204;
+            }
+
+            add_header Access-Control-Allow-Origin $cors_origin always;
+            proxy_pass http://api_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+}

--- a/tests/plugins/simply/mixed_case_variable/if_condition_inconsistent.conf
+++ b/tests/plugins/simply/mixed_case_variable/if_condition_inconsistent.conf
@@ -1,0 +1,8 @@
+server {
+    if ($http_host = "example.com") {
+        set $valid "1";
+    }
+    if ($HTTP_HOST ~ "^example\.com$") {
+        add_header X-Valid $valid;
+    }
+}

--- a/tests/plugins/simply/mixed_case_variable/inconsistent_set.conf
+++ b/tests/plugins/simply/mixed_case_variable/inconsistent_set.conf
@@ -1,0 +1,6 @@
+server {
+    location / {
+        set $My_Var "hello";
+        proxy_pass http://backend/$MY_VAR;
+    }
+}

--- a/tests/plugins/simply/mixed_case_variable/jwt_auth_mixed_case.conf
+++ b/tests/plugins/simply/mixed_case_variable/jwt_auth_mixed_case.conf
@@ -1,0 +1,20 @@
+server {
+    listen 443 ssl;
+    server_name api.example.com;
+
+    location /api/ {
+        set $jwt_token "";
+
+        if ($http_authorization ~ "^Bearer (.+)$") {
+            set $JWT_Token $1;
+        }
+
+        if ($jwt_token = "") {
+            return 401 "Unauthorized";
+        }
+
+        proxy_pass http://api_backend;
+        proxy_set_header X-JWT-Token $jwt_token;
+        proxy_set_header Host $host;
+    }
+}

--- a/tests/plugins/simply/mixed_case_variable/multiple_set_consistent_fp.conf
+++ b/tests/plugins/simply/mixed_case_variable/multiple_set_consistent_fp.conf
@@ -1,0 +1,9 @@
+server {
+    set $my_var "default";
+    location /a {
+        set $my_var "override_a";
+    }
+    location /b {
+        set $my_var "override_b";
+    }
+}

--- a/tests/plugins/simply/mixed_case_variable/multiple_set_same_var.conf
+++ b/tests/plugins/simply/mixed_case_variable/multiple_set_same_var.conf
@@ -1,0 +1,12 @@
+server {
+    set $Auth_Token "";
+
+    if ($request_method = POST) {
+        set $auth_token $http_authorization;
+    }
+
+    location /api {
+        set $AUTH_TOKEN $http_x_api_key;
+        proxy_set_header Authorization $Auth_Token;
+    }
+}

--- a/tests/plugins/simply/mixed_case_variable/multiple_variables_fp.conf
+++ b/tests/plugins/simply/mixed_case_variable/multiple_variables_fp.conf
@@ -1,0 +1,9 @@
+server {
+    set $upstream "backend1";
+    set $timeout "30";
+    location / {
+        proxy_pass http://$upstream;
+        proxy_read_timeout $timeout;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}

--- a/tests/plugins/simply/mixed_case_variable/rate_limit_mixed_case.conf
+++ b/tests/plugins/simply/mixed_case_variable/rate_limit_mixed_case.conf
@@ -1,0 +1,14 @@
+http {
+    limit_req_zone $RATE_KEY zone=api_limit:10m rate=100r/m;
+
+    server {
+        listen 80;
+
+        location /api {
+            set $rate_key "$remote_addr:$http_x_api_key";
+            limit_req zone=api_limit burst=20 nodelay;
+            proxy_pass http://api_backend;
+            proxy_set_header X-Forwarded-For $remote_addr;
+        }
+    }
+}

--- a/tests/plugins/simply/mixed_case_variable/rewrite_value_inconsistent.conf
+++ b/tests/plugins/simply/mixed_case_variable/rewrite_value_inconsistent.conf
@@ -1,0 +1,6 @@
+server {
+    location / {
+        set $backend "server1";
+        rewrite ^ /$BACKEND last;
+    }
+}


### PR DESCRIPTION
Detects when the same NGINX variable is referenced with inconsistent casing in one config (e.g. `$My_Var` vs `$MY_VAR`). Since NGINX normalizes all names to lowercase these are the same variable, but the inconsistency looks like a typo.

- Severity: LOW
- 7 trigger configs, 6 false-positive configs
- Documentation in `docs/en/plugins/mixed_case_variable.md`
- Registered in `mkdocs.yml`, `docs/en/index.md`, and `README.md`