### PR TITLE
Replace UNSPECIFIED severity with INFORMATION

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ include /etc/nginx/sites/default.conf;
 
 ==================== Summary ===================
 Total issues:
-    Unspecified: 0
+    Informational: 0
     Low: 0
     Medium: 0
     High: 1

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -170,7 +170,7 @@ include /etc/nginx/sites/default.conf;
 
 ==================== Summary ===================
 Total issues:
-    Unspecified: 0
+    Informational: 0
     Low: 0
     Medium: 0
     High: 1

--- a/docs/en/plugins/regex_redos.md
+++ b/docs/en/plugins/regex_redos.md
@@ -78,10 +78,7 @@ url = http://127.0.0.1:8080/
 
 ### Severity
 
-This plugin reports different severities depending on the result of the external checker:
-
-- MEDIUM, if the external checker reports the expression is vulnerable to ReDoS.
-- UNSPECIFIED, if the plugin cannot evaluate the expression for one reason or another (server failure, network failure, invalid JSON, etc.)
+This plugin reports issues at MEDIUM severity when the external checker confirms a regex is vulnerable to ReDoS. If the checker cannot evaluate an expression (server failure, network failure, invalid JSON, unknown complexity), nothing is reported.
 
 ### When this check is skipped
 

--- a/gixy/core/config.py
+++ b/gixy/core/config.py
@@ -6,7 +6,7 @@ class Config(object):
         self,
         plugins=None,
         skips=None,
-        severity=gixy.severity.UNSPECIFIED,
+        severity=gixy.severity.INFORMATION,
         output_format=None,
         output_file=None,
         allow_includes=True,

--- a/gixy/core/severity.py
+++ b/gixy/core/severity.py
@@ -1,8 +1,8 @@
-UNSPECIFIED = "UNSPECIFIED"
+INFORMATION = "INFORMATION"
 LOW = "LOW"
 MEDIUM = "MEDIUM"
 HIGH = "HIGH"
-ALL = [UNSPECIFIED, LOW, MEDIUM, HIGH]
+ALL = [INFORMATION, LOW, MEDIUM, HIGH]
 
 
 def is_acceptable(current_severity, min_severity):

--- a/gixy/formatters/templates/console.j2
+++ b/gixy/formatters/templates/console.j2
@@ -1,4 +1,4 @@
-{% set colors = {'DEF': '\033[0m', 'TITLE': '\033[95m', 'UNSPECIFIED': '\033[0m', 'LOW': '\033[94m', 'MEDIUM': '\033[93m', 'HIGH': '\033[91m'} %}
+{% set colors = {'DEF': '\033[0m', 'TITLE': '\033[95m', 'INFORMATION': '\033[0m', 'LOW': '\033[94m', 'MEDIUM': '\033[93m', 'HIGH': '\033[91m'} %}
 
 {{ colors.TITLE }}==================== Results ==================={{ colors.DEF }}
 {% for path, issues in reports.items() %}
@@ -37,7 +37,7 @@ Pseudo config:
 {% if stats %}
 {{ colors.TITLE }}==================== Summary ==================={{ colors.DEF }}
 Total issues:
-    Unspecified: {{ stats.UNSPECIFIED }}
+    Informational: {{ stats.INFORMATION }}
     Low: {{ stats.LOW }}
     Medium: {{ stats.MEDIUM }}
     High: {{ stats.HIGH }}

--- a/gixy/formatters/templates/text.j2
+++ b/gixy/formatters/templates/text.j2
@@ -37,7 +37,7 @@ Pseudo config:
 {% if stats %}
 ==================== Summary ===================
 Total issues:
-    Unspecified: {{ stats.UNSPECIFIED }}
+    Informational: {{ stats.INFORMATION }}
     Low: {{ stats.LOW }}
     Medium: {{ stats.MEDIUM }}
     High: {{ stats.HIGH }}

--- a/gixy/plugins/mixed_case_variable.py
+++ b/gixy/plugins/mixed_case_variable.py
@@ -21,7 +21,7 @@ class mixed_case_variable(Plugin):
     """
 
     summary = "Same variable referenced with inconsistent case."
-    severity = gixy.severity.LOW
+    severity = gixy.severity.INFORMATION
     description = (
         "NGINX normalizes all variable names to lowercase. "
         "Referencing the same variable with different cases in one config "

--- a/gixy/plugins/plugin.py
+++ b/gixy/plugins/plugin.py
@@ -6,7 +6,7 @@ class Plugin(object):
     summary = ""
     description = ""
     help_url = ""
-    severity = gixy.severity.UNSPECIFIED
+    severity = gixy.severity.INFORMATION
     directives = []
     options = {}
 

--- a/gixy/plugins/regex_redos.py
+++ b/gixy/plugins/regex_redos.py
@@ -36,7 +36,6 @@ class regex_redos(Plugin):
 
     summary = "Regular expression denial of service (ReDoS)."
     severity = gixy.severity.MEDIUM
-    unknown_severity = gixy.severity.UNSPECIFIED
     description = (
         "Regular expressions with the potential for catastrophic backtracking "
         "allow an nginx server to be denial-of-service attacked with very low "
@@ -84,25 +83,16 @@ class regex_redos(Plugin):
                 timeout=60,
             )
         except Exception:
-            self.add_issue(
-                directive=directive, reason=fail_reason, severity=self.unknown_severity
-            )
             return
 
         # If we get a non-200 response, skip.
         if response.status_code != 200:
-            self.add_issue(
-                directive=directive, reason=fail_reason, severity=self.unknown_severity
-            )
             return
 
         # Attempt to parse the JSON response.
         try:
             response_json = response.json()
         except ValueError:
-            self.add_issue(
-                directive=directive, reason=fail_reason, severity=self.unknown_severity
-            )
             return
 
         # Ensure the expected data structure is present and matches the pattern.
@@ -112,9 +102,6 @@ class regex_redos(Plugin):
             or "source" not in response_json["1"]
             or response_json["1"]["source"] != regex_pattern
         ):
-            self.add_issue(
-                directive=directive, reason=fail_reason, severity=self.unknown_severity
-            )
             return
 
         recheck = response_json["1"]
@@ -124,12 +111,7 @@ class regex_redos(Plugin):
         if status not in ("vulnerable", "unknown"):
             return
 
-        # If the status is unknown, add a low-severity issue (likely the server timed out)
         if status == "unknown":
-            reason = f"Could not determine ReDoS complexity for regex: {regex_pattern}."
-            self.add_issue(
-                directive=directive, reason=reason, severity=self.unknown_severity
-            )
             return
 
         # Status is 'vulnerable' here. Report as a high-severity issue.

--- a/tests/plugins/simply/mixed_case_variable/config.json
+++ b/tests/plugins/simply/mixed_case_variable/config.json
@@ -1,3 +1,3 @@
 {
-  "severity": "LOW"
+  "severity": "INFORMATION"
 }


### PR DESCRIPTION
- Rename `UNSPECIFIED` → `INFORMATION` throughout: `severity.py`, `plugin.py`, `config.py`, formatters, templates, docs, and tests
- Move `mixed_case_variable` from `LOW` to `INFORMATION`: it flags a readability/style issue, not a security finding
- `regex_redos`: silently skip when complexity cannot be determined (network error, non-200 response, parse error, recheck `unknown` status) rather than emitting an ambiguous `UNSPECIFIED` issue