### PR TITLE
Fix MapBlock and GeoBlock __str__ to preserve original casing

### DIFF
--- a/gixy/directives/block.py
+++ b/gixy/directives/block.py
@@ -319,7 +319,7 @@ class MapBlock(Block):
         ]
 
     def __str__(self):
-        return "{0} {1} ${2} {{".format(self.nginx_name, self.source, self.variable)
+        return "{0} {1} {2} {{".format(self.nginx_name, self.args[0], self.args[1])
 
 
 class GeoBlock(Block):
@@ -384,4 +384,4 @@ class GeoBlock(Block):
         ]
 
     def __str__(self):
-        return "{0} {1} ${2} {{".format(self.nginx_name, self.source, self.variable)
+        return "{0} {1} {{".format(self.nginx_name, " ".join(self.args))


### PR DESCRIPTION
`MapBlock.__str__` and `GeoBlock.__str__` both used their normalized (`self.source`, `self.variable`) attributes for rendering, which lowercased variable names in pseudo config output regardless of what the user wrote.

`GeoBlock.__str__` also expanded the implicit `$remote_addr` source into the output for 1-arg geo blocks, adding something the user never wrote.

Both are fixed to use `self.args` directly.