### PR TITLE
Add unnamed_groups plugin (CVE-2026-42945)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Gixy-Next can detect a wide range of NGINX security and performance misconfigura
 *   [[status_page_exposed] Ensures that status_page is not exposed to the world](https://gixy.io/plugins/status_page_exposed/)
 *   [[try_files_is_evil_too] `try_files` directive is evil without open_file_cache](https://gixy.io/plugins/try_files_is_evil_too/)
 *   [[unanchored_regex] Unanchored regular expressions](https://gixy.io/plugins/unanchored_regex/)
+*   [[unnamed_groups] Unnamed capture groups in rewrite query string](https://gixy.io/plugins/unnamed_groups/)
 *   [[valid_referers] none in valid_referers](https://gixy.io/plugins/valid_referers/)
 *   [[version_disclosure] Using insecure values for server_tokens](https://gixy.io/plugins/version_disclosure/)
 *   [[worker_rlimit_nofile_vs_connections] `worker_rlimit_nofile` must be at least twice `worker_connections`](https://gixy.io/plugins/worker_rlimit_nofile_vs_connections/)

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -110,6 +110,7 @@ Gixy-Next can detect a wide range of NGINX security and performance misconfigura
 *   [[status_page_exposed] Ensures that status_page is not exposed to the world](https://gixy.io/plugins/status_page_exposed/)
 *   [[try_files_is_evil_too] `try_files` directive is evil without open_file_cache](https://gixy.io/plugins/try_files_is_evil_too/)
 *   [[unanchored_regex] Unanchored regular expressions](https://gixy.io/plugins/unanchored_regex/)
+*   [[unnamed_groups] Unnamed capture groups in rewrite query string](https://gixy.io/plugins/unnamed_groups/)
 *   [[valid_referers] none in valid_referers](https://gixy.io/plugins/valid_referers/)
 *   [[version_disclosure] Using insecure values for server_tokens](https://gixy.io/plugins/version_disclosure/)
 *   [[worker_rlimit_nofile_vs_connections] `worker_rlimit_nofile` must be at least twice `worker_connections`](https://gixy.io/plugins/worker_rlimit_nofile_vs_connections/)

--- a/docs/en/plugins/unnamed_groups.md
+++ b/docs/en/plugins/unnamed_groups.md
@@ -1,0 +1,48 @@
+---
+title: "Unnamed capture groups in rewrite query string"
+description: "Detects rewrite directives that reference numeric capture groups ($1, $2, …) in the query-string portion of the replacement URL — the pattern associated with CVE-2026-42945 ('nginx rift')."
+---
+
+# [unnamed_groups] Unnamed capture groups in rewrite query string
+
+## What this check looks for
+
+This plugin flags `rewrite` directives where numeric capture group references (`$1`, `$2`, …) appear **after the `?`** in the replacement URL — the specific pattern associated with CVE-2026-42945.
+
+## Why this is informational
+
+CVE-2026-42945 ("nginx rift") is a vulnerability in nginx itself, not in the configuration. Whether a given deployment is actually exploitable depends entirely on the nginx version and whether the relevant patch has been applied — information that is not present in a config file. Gixy-Next therefore reports this at **INFORMATION** severity rather than as a confirmed vulnerability.
+
+The recommended fix — switching from positional (`$1`, `$2`) to named capture groups — also improves readability by making the purpose of each substitution explicit. This benefit applies regardless of nginx version.
+
+## Bad configuration
+
+```nginx
+server {
+    location / {
+        rewrite ^/users/([0-9]+)/profile/(.*)$ /profile.php?id=$1&tab=$2 last;
+    }
+}
+```
+
+`$1` and `$2` are positional references to unnamed capture groups. When they appear in the query string portion of the replacement URL this matches the CVE-2026-42945 pattern.
+
+## Better configuration
+
+Use named capture groups and reference them by name:
+
+```nginx
+server {
+    location / {
+        rewrite ^/users/(?<id>[0-9]+)/profile/(?<tab>.*)$ /profile.php?id=$id&tab=$tab last;
+    }
+}
+```
+
+This eliminates the CVE-2026-42945 pattern entirely and makes the intent of each substitution self-documenting.
+
+## Additional notes
+
+- Only references appearing **after the `?`** in the replacement URL are flagged. Positional references in the path portion (before `?`) are not part of the CVE pattern and are not reported.
+- Variables that contain digits but are not positional capture group references (e.g., `$arg_id`, `$http2_push`) are not flagged.
+- For more information see [CVE-2026-42945 on NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-42945).

--- a/gixy/plugins/unnamed_groups.py
+++ b/gixy/plugins/unnamed_groups.py
@@ -5,31 +5,38 @@ from gixy.plugins.plugin import Plugin
 
 
 class unnamed_groups(Plugin):
+    r"""
+    Detects rewrite directives that reference numeric capture groups ($1, $2, …)
+    in the query-string portion of the replacement URL — the pattern associated
+    with CVE-2026-42945 ("nginx rift").
+
+    Whether any given nginx build is exploitable depends entirely on the nginx
+    version and patch status, which cannot be determined from a config file.
+    This finding is therefore informational: switching to named capture groups
+    is the recommended fix and also improves readability independent of the CVE.
+
+    Flagged:
+        rewrite ^/users/([0-9]+)/profile/(.*)$ /profile.php?id=$1&tab=$2 last;
+
+    Preferred:
+        rewrite ^/users/(?<id>[0-9]+)/profile/(?<tab>.*)$ /profile.php?id=$id&tab=$tab last;
     """
-    Detects rewrite groups vulnerable to CVE-2026-42945
 
-    rewrite ^/users/([0-9]+)/profile/(.*)$ /profile.php?id=$1&tab=$2 last;
-
-    Directives like this where there is an unnamed group referenced after a "?"
-    in the target are vulnerable.
-    """
-
-    summary = "Using numeric regex capture groups in a rewrite query string."
-    severity = gixy.severity.MEDIUM
+    summary = "Numeric capture group reference in rewrite query string (CVE-2026-42945)."
+    severity = gixy.severity.INFORMATION
     description = (
-        "Referencing numeric capture groups (like $1, $2) after a ? in a rewrite "
-        "target can expose rewrite handling issues."
+        "Referencing numeric capture groups ($1, $2, …) after a '?' in a rewrite "
+        "replacement is the pattern targeted by CVE-2026-42945 ('nginx rift'). "
+        "Whether the instance is exploitable depends on the nginx version and patch "
+        "status, which is not visible in the config. Switching to named capture groups "
+        "is the recommended mitigation and also improves readability."
     )
     help_url = "https://gixy.io/plugins/unnamed_groups/"
     directives = ["rewrite"]
 
-    CAPTURE_GROUP_REF = re.compile(r"\$([1-9]\d*)")
+    _CAPTURE_GROUP_REF = re.compile(r"\$([1-9]\d*)")
 
     def audit(self, directive):
-        if directive.name == "rewrite":
-            self._audit_rewrite(directive)
-
-    def _audit_rewrite(self, directive):
         if len(directive.args) < 2:
             return
 
@@ -38,13 +45,15 @@ class unnamed_groups(Plugin):
             return
 
         query_string = replacement.split("?", 1)[1]
-        capture_refs = self.CAPTURE_GROUP_REF.findall(query_string)
+        capture_refs = self._CAPTURE_GROUP_REF.findall(query_string)
         if not capture_refs:
             return
 
         refs = ", ".join(f"${ref}" for ref in capture_refs)
-        reason = (
-            f"The rewrite target references numeric capture group(s) {refs} "
-            "after a ? in the replacement URL."
+        self.add_issue(
+            directive=directive,
+            reason=(
+                f"Rewrite target uses numeric capture group(s) {refs} in the query "
+                "string. See CVE-2026-42945."
+            ),
         )
-        self.add_issue(directive=directive, reason=reason)

--- a/gixy/plugins/unnamed_groups.py
+++ b/gixy/plugins/unnamed_groups.py
@@ -1,0 +1,50 @@
+import re
+
+import gixy
+from gixy.plugins.plugin import Plugin
+
+
+class unnamed_groups(Plugin):
+    """
+    Detects rewrite groups vulnerable to CVE-2026-42945
+
+    rewrite ^/users/([0-9]+)/profile/(.*)$ /profile.php?id=$1&tab=$2 last;
+
+    Directives like this where there is an unnamed group referenced after a "?"
+    in the target are vulnerable.
+    """
+
+    summary = "Using numeric regex capture groups in a rewrite query string."
+    severity = gixy.severity.MEDIUM
+    description = (
+        "Referencing numeric capture groups (like $1, $2) after a ? in a rewrite "
+        "target can expose rewrite handling issues."
+    )
+    help_url = "https://gixy.io/plugins/unnamed_groups/"
+    directives = ["rewrite"]
+
+    CAPTURE_GROUP_REF = re.compile(r"\$([1-9]\d*)")
+
+    def audit(self, directive):
+        if directive.name == "rewrite":
+            self._audit_rewrite(directive)
+
+    def _audit_rewrite(self, directive):
+        if len(directive.args) < 2:
+            return
+
+        replacement = directive.args[1]
+        if "?" not in replacement:
+            return
+
+        query_string = replacement.split("?", 1)[1]
+        capture_refs = self.CAPTURE_GROUP_REF.findall(query_string)
+        if not capture_refs:
+            return
+
+        refs = ", ".join(f"${ref}" for ref in capture_refs)
+        reason = (
+            f"The rewrite target references numeric capture group(s) {refs} "
+            "after a ? in the replacement URL."
+        )
+        self.add_issue(directive=directive, reason=reason)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
     - plugins/status_page_exposed.md
     - plugins/try_files_is_evil_too.md
     - plugins/unanchored_regex.md
+    - plugins/unnamed_groups.md
     - plugins/valid_referers.md
     - plugins/version_disclosure.md
     - plugins/worker_rlimit_nofile_vs_connections.md

--- a/tests/plugins/simply/unnamed_groups/config.json
+++ b/tests/plugins/simply/unnamed_groups/config.json
@@ -1,0 +1,3 @@
+{
+  "severity": "INFORMATION"
+}

--- a/tests/plugins/simply/unnamed_groups/unnamed_groups.conf
+++ b/tests/plugins/simply/unnamed_groups/unnamed_groups.conf
@@ -1,0 +1,5 @@
+server {
+    location / {
+        rewrite ^/users/([0-9]+)/profile/(.*)$ /profile.php?id=$1&tab=$2 last;
+    }
+}

--- a/tests/plugins/simply/unnamed_groups/unnamed_groups_fp.conf
+++ b/tests/plugins/simply/unnamed_groups/unnamed_groups_fp.conf
@@ -2,6 +2,6 @@ server {
     location / {
         rewrite ^/(.*)$ /$1?ok=1 last;
         rewrite ^/(.*)$ /profile/$1 last;
-        rewrite ^/users/(?<id>[0-9]+)$ /profile.php?id=$arg_id last;
+        rewrite ^/users/(?<id>[0-9]+)$ /profile.php?id=$id last;
     }
 }

--- a/tests/plugins/simply/unnamed_groups/unnamed_groups_fp.conf
+++ b/tests/plugins/simply/unnamed_groups/unnamed_groups_fp.conf
@@ -1,0 +1,7 @@
+server {
+    location / {
+        rewrite ^/(.*)$ /$1?ok=1 last;
+        rewrite ^/(.*)$ /profile/$1 last;
+        rewrite ^/users/(?<id>[0-9]+)$ /profile.php?id=$arg_id last;
+    }
+}


### PR DESCRIPTION
Closes #11. Based on #10 by @stephenpaulger.

Detects `rewrite` directives that reference numeric capture groups (`$1`, `$2`, …) after the `?` in the replacement URL — the pattern associated with CVE-2026-42945 ("nginx rift").

Reported at **INFORMATION** severity because exploitability depends entirely on the nginx version and patch status, which cannot be determined from a config file. The fix (named capture groups) is also a readability improvement independent of the CVE.

Changes on top of @stephenpaulger's original commit:
- Severity MEDIUM → INFORMATION
- Description and reason updated to reference CVE-2026-42945 explicitly
- `_audit_rewrite` inlined into `audit`; regex renamed to `_CAPTURE_GROUP_REF`
- FP fixture: corrected `$arg_id` → `$id` (named group ref, not query param)
- Added `config.json` test fixture asserting INFORMATION severity
- Added `docs/en/plugins/unnamed_groups.md`
- Added to `mkdocs.yml`, `docs/en/index.md`, `README.md`