### PR TITLE
Clarify unnamed_groups: CVE pattern only; no action if patched

### DIFF
--- a/docs/en/plugins/unnamed_groups.md
+++ b/docs/en/plugins/unnamed_groups.md
@@ -7,13 +7,15 @@ description: "Detects rewrite directives that use numeric capture group referenc
 
 ## What this check looks for
 
-This plugin flags `rewrite` directives where the replacement URL contains a `?` and also references positional capture groups (`$1`, `$2`, …) anywhere in that replacement — before or after the `?`.
+This plugin flags a specific pattern associated with CVE-2026-42945: a `rewrite` directive whose replacement URL contains a `?` **and** references numeric capture groups (`$1`, `$2`, …) anywhere in that replacement. Not all uses of unnamed capture groups are flagged — only this combination.
 
 ## Why this is a problem
 
-CVE-2026-42945 ("nginx rift") is a bug in nginx itself. The only real fix is to update nginx to a patched version. Whether a given deployment is vulnerable depends on the nginx version — Gixy-Next cannot determine this from the config alone, so this is reported as **INFORMATION**.
+CVE-2026-42945 ("nginx rift") is a bug in nginx itself. The only real fix is to update nginx to a patched version. If you are already running a patched version (NGINX Open Source 1.30.1+ or 1.31.0+, or NGINX Plus R32 P6+ / R36 P4+), **no action is required** — this finding does not apply to you.
 
-Switching to named capture groups avoids the vulnerable pattern on unpatched versions and is worth doing regardless: `$id` and `$tab` are self-documenting in a way that `$1` and `$2` are not, making rewrites easier to understand and maintain.
+Because Gixy-Next cannot determine the nginx version from the config alone, any matching pattern is reported as **INFORMATION** rather than a warning.
+
+On unpatched versions, switching to named capture groups avoids the vulnerable pattern. Named groups are also worth adopting regardless: `$id` and `$tab` are self-documenting in a way that `$1` and `$2` are not.
 
 ## Bad configuration
 
@@ -37,5 +39,6 @@ rewrite ^/(?<path>.*)$ /$path?v=2 last;
 
 - Rewrites with no `?` in the replacement are not flagged, even if they use positional captures.
 - Named capture group references (`$id`, `$path`, etc.) and nginx built-in variables (`$arg_id`, etc.) are not flagged.
-- Affected versions: NGINX Open Source 0.6.27–1.30.0 (fixed in 1.30.1/1.31.0), NGINX Plus R32–R36.
+- If nginx is already patched, this finding requires no action — it is reported as INFORMATION precisely because vulnerability depends on the nginx version.
+- Affected (unpatched) versions: NGINX Open Source 0.6.27–1.30.0, NGINX Plus R32–R36.
 - For more information see [CVE-2026-42945 on NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-42945).

--- a/gixy/plugins/unnamed_groups.py
+++ b/gixy/plugins/unnamed_groups.py
@@ -14,10 +14,13 @@ class unnamed_groups(Plugin):
     summary = "Unnamed capture group reference in rewrite with query string (CVE-2026-42945)."
     severity = gixy.severity.INFORMATION
     description = (
-        "Using numeric capture groups ($1, $2, …) in a rewrite replacement that "
-        "contains a query string ('?') is associated with CVE-2026-42945 — a bug in "
-        "nginx itself, fixed by updating nginx. Switching to named capture groups "
-        "avoids the pattern on unpatched versions and improves readability."
+        "This check flags a specific pattern associated with CVE-2026-42945: a rewrite "
+        "replacement that contains both a query string ('?') and numeric capture group "
+        "references ($1, $2, …). Not all uses of unnamed capture groups are flagged — "
+        "only this combination. The underlying bug is in nginx itself; if you are running "
+        "a patched version (1.30.1+/1.31.0+, or NGINX Plus R32 P6+/R36 P4+), no action "
+        "is required. On unpatched versions, switching to named capture groups avoids the "
+        "vulnerable pattern and improves readability."
     )
     help_url = "https://gixy.io/plugins/unnamed_groups/"
     directives = ["rewrite"]


### PR DESCRIPTION
Makes two things explicit in the plugin description and doc:

- This plugin only flags the specific CVE-2026-42945 pattern (unnamed `$N` ref + `?` in replacement) — not all uses of unnamed capture groups.
- If nginx is already patched (1.30.1+/1.31.0+, NGINX Plus R32 P6+/R36 P4+), no action is required.