### PR TITLE
Release 0.2.0

### DIFF
--- a/gixy/__init__.py
+++ b/gixy/__init__.py
@@ -2,4 +2,4 @@
 
 from gixy.core import severity
 
-version = "0.1.6"
+version = "0.2.0"


### PR DESCRIPTION
## 0.2.0

Bumps version from 0.1.6 → 0.2.0.

### New plugins
- **`unnamed_groups`** — detects numeric capture group references (`$1`, `$2`, …) in rewrite replacements that also contain a query string, the pattern associated with CVE-2026-42945 (INFORMATION)
- **`http2_misdirected_request`** — flags TLS `default_server` blocks with `ssl_reject_handshake on` and HTTP/2 enabled that lack a `location / { return 421; }` safeguard (LOW)
- **`quic_bpf_reuseport`** — detects `quic_bpf on` combined with `reuseport` and multiple workers, which silently drops ~50% of QUIC connections after every reload (HIGH)
- **`mixed_case_variable`** — detects the same nginx variable referenced with inconsistent casing, which nginx normalises to lowercase but looks like two distinct variables in source (LOW)

### Correctness fixes
- Variable scope: `set`, `map`, `geo` variables are now visible throughout their enclosing scope regardless of source order, matching nginx's parse-time registration semantics (#12)
- Variable name case: all variable names are normalised to lowercase throughout the parser and plugins, matching nginx's `ngx_strlow()` behaviour (#17)
- `MapBlock` and `GeoBlock` `__str__` now use raw args, preserving original casing in output (#22)
- `origins`: fixed a self-comparison bug (`same_origin(x, x)` always true) that made one branch permanently dead code
- `invalid_regex`: `!~` and `!~*` operators are now included in capture group validation; also flags `$N` references inside `!~` blocks where the group exists in the pattern but can never be captured (block only runs on non-match)
- `status_page_exposed`: corrected `help_url` (was pointing to `stale_dns_cache`)

### Bug fixes (#26)
- `http2_misdirected_request`: respect `http2 off;` at server level overriding a global `http2 on;`; add `.lower()` to all `on`/`off` comparisons
- `quic_bpf_reuseport`: add `.lower()` so `quic_bpf ON;` is not missed
- `try_files_is_evil_too`: add `.lower()` so `open_file_cache OFF;` is recognised
- `valid_referers`: case-insensitive `none` check so `valid_referers NONE ...;` is detected
- `regex_redos`: remove dead `fail_reason` variable