### PR TITLE
Add ssl_stapling_without_resolver plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Gixy-Next can detect a wide range of NGINX security and performance misconfigura
 *   [[regex_redos] Regular expression denial of service (ReDoS)](https://gixy.io/plugins/regex_redos/)
 *   [[resolver_external] Using external DNS nameservers](https://gixy.io/plugins/resolver_external/)
 *   [[return_bypasses_allow_deny] Return directive bypasses allow/deny restrictions](https://gixy.io/plugins/return_bypasses_allow_deny/)
+*   [[ssl_stapling_without_resolver] OCSP stapling silently fails without a resolver](https://gixy.io/plugins/ssl_stapling_without_resolver/)
 *   [[ssrf] Server Side Request Forgery](https://gixy.io/plugins/ssrf/)
 *   [[stale_dns_cache] Outdated/stale cached DNS records used in proxy_pass](https://gixy.io/plugins/stale_dns_cache/)
 *   [[status_page_exposed] Ensures that status_page is not exposed to the world](https://gixy.io/plugins/status_page_exposed/)

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -105,6 +105,7 @@ Gixy-Next can detect a wide range of NGINX security and performance misconfigura
 *   [[regex_redos] Regular expression denial of service (ReDoS)](https://gixy.io/plugins/regex_redos/)
 *   [[resolver_external] Using external DNS nameservers](https://gixy.io/plugins/resolver_external/)
 *   [[return_bypasses_allow_deny] Return directive bypasses allow/deny restrictions](https://gixy.io/plugins/return_bypasses_allow_deny/)
+*   [[ssl_stapling_without_resolver] OCSP stapling silently fails without a resolver](https://gixy.io/plugins/ssl_stapling_without_resolver/)
 *   [[ssrf] Server Side Request Forgery](https://gixy.io/plugins/ssrf/)
 *   [[stale_dns_cache] Outdated/stale cached DNS records used in proxy_pass](https://gixy.io/plugins/stale_dns_cache/)
 *   [[status_page_exposed] Ensures that status_page is not exposed to the world](https://gixy.io/plugins/status_page_exposed/)

--- a/docs/en/plugins/ssl_stapling_without_resolver.md
+++ b/docs/en/plugins/ssl_stapling_without_resolver.md
@@ -1,0 +1,83 @@
+---
+title: "OCSP Stapling Without Resolver"
+description: "Detects SSL servers where ssl_stapling on is effective but no resolver directive is reachable in scope, causing OCSP stapling to silently fail at runtime."
+---
+
+# [ssl_stapling_without_resolver] OCSP stapling silently fails without a resolver
+
+## What this check looks for
+
+This plugin flags `server` blocks where all of the following are true:
+
+* The server handles SSL/TLS connections (`listen ... ssl;`, `listen ... quic;`, or `listen ... http3;`)
+* `ssl_stapling on;` is in effect — declared directly in the server or inherited from the enclosing `http {}` block
+* No `resolver` directive is reachable in the server's scope or any enclosing scope
+* No `ssl_stapling_file` is set (a pre-loaded OCSP response removes the need for a resolver)
+
+## Why this is a problem
+
+`ssl_stapling` directs nginx to fetch a signed OCSP response from the certificate authority and staple it to the TLS handshake. To reach the CA's OCSP responder, nginx must resolve the responder hostname — and it can only do that if a `resolver` is configured in the same or a parent scope.
+
+Without one, nginx logs a warning at startup and silently disables stapling. Clients then have to make their own OCSP requests during every handshake, adding a round trip of latency and defeating the point of enabling stapling in the first place.
+
+## Bad configuration
+
+`ssl_stapling on` in the server block, but no resolver anywhere:
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name example.com;
+
+    ssl_certificate     /etc/ssl/certs/example.com.pem;
+    ssl_certificate_key /etc/ssl/private/example.com.key;
+
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    # no resolver — stapling silently fails
+}
+```
+
+Inherited from `http {}` with still no resolver:
+
+```nginx
+http {
+    ssl_stapling on;     # applies to every server below
+
+    server {
+        listen 443 ssl;
+        ssl_certificate     /etc/ssl/certs/example.com.pem;
+        ssl_certificate_key /etc/ssl/private/example.com.key;
+        # no resolver anywhere up the chain
+    }
+}
+```
+
+## Better configuration
+
+Put the resolver at `http` level so every SSL server inherits it:
+
+```nginx
+http {
+    resolver 1.1.1.1 8.8.8.8 valid=300s ipv6=off;
+    resolver_timeout 5s;
+
+    ssl_stapling on;
+    ssl_stapling_verify on;
+
+    server {
+        listen 443 ssl;
+        server_name example.com;
+
+        ssl_certificate     /etc/ssl/certs/example.com.pem;
+        ssl_certificate_key /etc/ssl/private/example.com.key;
+    }
+}
+```
+
+## Additional notes
+
+* A `resolver` declared in the same server block is also sufficient; http-level is just the most common pattern.
+* If you pre-load the stapled response via `ssl_stapling_file`, nginx uses that file directly and does not need a resolver.
+* A server that overrides with `ssl_stapling off;` is not flagged, even when the http block enables stapling globally.
+* Non-SSL servers (plain `listen 80;`) are skipped — stapling is irrelevant there.

--- a/gixy/plugins/ssl_stapling_without_resolver.py
+++ b/gixy/plugins/ssl_stapling_without_resolver.py
@@ -1,0 +1,68 @@
+import gixy
+from gixy.plugins.plugin import Plugin
+
+
+class ssl_stapling_without_resolver(Plugin):
+    """Flag SSL servers where ssl_stapling is on but no resolver is reachable in scope."""
+
+    summary = "ssl_stapling enabled without a resolver — OCSP stapling silently fails."
+    severity = gixy.severity.MEDIUM
+    description = (
+        "`ssl_stapling on` requires a `resolver` directive reachable in the same or a parent "
+        "scope. Without it nginx cannot fetch the OCSP response and stapling silently fails — "
+        "clients fall back to their own OCSP queries, adding handshake latency. "
+        "Add `resolver` to the server or http block, or pre-load the stapled response with "
+        "`ssl_stapling_file`."
+    )
+    help_url = "https://gixy.io/plugins/ssl_stapling_without_resolver/"
+    directives = ["server"]
+
+    def audit(self, server):
+        if not server.is_block:
+            return
+
+        if not self._is_ssl_server(server):
+            return
+
+        stapling = self._effective(server, "ssl_stapling")
+        if not stapling or not stapling.args or stapling.args[0].lower() != "on":
+            return
+
+        # ssl_stapling_file pre-loads the OCSP response; no resolver needed.
+        if self._in_scope(server, "ssl_stapling_file"):
+            return
+
+        if self._in_scope(server, "resolver"):
+            return
+
+        self.add_issue(
+            directive=stapling,
+            reason=(
+                "ssl_stapling is enabled but no `resolver` is reachable in this server's scope — "
+                "OCSP stapling will silently fail at runtime."
+            ),
+        )
+
+    def _is_ssl_server(self, server):
+        for listen in server.find("listen"):
+            if any(arg.lower() in ("ssl", "quic", "http3") for arg in listen.args):
+                return True
+        return False
+
+    def _effective(self, server, name):
+        own = server.some(name)
+        if own:
+            return own
+        for parent in server.parents:
+            inherited = parent.some(name, flat=False)
+            if inherited:
+                return inherited
+        return None
+
+    def _in_scope(self, server, name):
+        if server.some(name):
+            return True
+        for parent in server.parents:
+            if parent.some(name, flat=False):
+                return True
+        return False

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
     - plugins/regex_redos.md
     - plugins/resolver_external.md
     - plugins/return_bypasses_allow_deny.md
+    - plugins/ssl_stapling_without_resolver.md
     - plugins/ssrf.md
     - plugins/stale_dns_cache.md
     - plugins/status_page_exposed.md

--- a/tests/plugins/simply/ssl_stapling_without_resolver/config.json
+++ b/tests/plugins/simply/ssl_stapling_without_resolver/config.json
@@ -1,0 +1,3 @@
+{
+  "severity": "MEDIUM"
+}

--- a/tests/plugins/simply/ssl_stapling_without_resolver/http_only_server_fp.conf
+++ b/tests/plugins/simply/ssl_stapling_without_resolver/http_only_server_fp.conf
@@ -1,0 +1,10 @@
+http {
+    ssl_stapling on;
+
+    server {
+        listen 80;
+        server_name example.com;
+
+        return 301 https://$host$request_uri;
+    }
+}

--- a/tests/plugins/simply/ssl_stapling_without_resolver/inherited_from_http.conf
+++ b/tests/plugins/simply/ssl_stapling_without_resolver/inherited_from_http.conf
@@ -1,0 +1,12 @@
+http {
+    ssl_stapling on;
+    ssl_stapling_verify on;
+
+    server {
+        listen 443 ssl;
+        server_name example.com;
+
+        ssl_certificate     /etc/ssl/certs/example.com.pem;
+        ssl_certificate_key /etc/ssl/private/example.com.key;
+    }
+}

--- a/tests/plugins/simply/ssl_stapling_without_resolver/no_resolver.conf
+++ b/tests/plugins/simply/ssl_stapling_without_resolver/no_resolver.conf
@@ -1,0 +1,10 @@
+server {
+    listen 443 ssl;
+    server_name example.com;
+
+    ssl_certificate     /etc/ssl/certs/example.com.pem;
+    ssl_certificate_key /etc/ssl/private/example.com.key;
+
+    ssl_stapling on;
+    ssl_stapling_verify on;
+}

--- a/tests/plugins/simply/ssl_stapling_without_resolver/resolver_in_http_fp.conf
+++ b/tests/plugins/simply/ssl_stapling_without_resolver/resolver_in_http_fp.conf
@@ -1,0 +1,15 @@
+http {
+    resolver 1.1.1.1 8.8.8.8 valid=300s ipv6=off;
+    resolver_timeout 5s;
+
+    ssl_stapling on;
+    ssl_stapling_verify on;
+
+    server {
+        listen 443 ssl;
+        server_name example.com;
+
+        ssl_certificate     /etc/ssl/certs/example.com.pem;
+        ssl_certificate_key /etc/ssl/private/example.com.key;
+    }
+}

--- a/tests/plugins/simply/ssl_stapling_without_resolver/resolver_in_server_fp.conf
+++ b/tests/plugins/simply/ssl_stapling_without_resolver/resolver_in_server_fp.conf
@@ -1,0 +1,13 @@
+server {
+    listen 443 ssl;
+    server_name example.com;
+
+    ssl_certificate     /etc/ssl/certs/example.com.pem;
+    ssl_certificate_key /etc/ssl/private/example.com.key;
+
+    resolver 1.1.1.1 8.8.8.8 valid=300s ipv6=off;
+    resolver_timeout 5s;
+
+    ssl_stapling on;
+    ssl_stapling_verify on;
+}

--- a/tests/plugins/simply/ssl_stapling_without_resolver/server_overrides_off_fp.conf
+++ b/tests/plugins/simply/ssl_stapling_without_resolver/server_overrides_off_fp.conf
@@ -1,0 +1,13 @@
+http {
+    ssl_stapling on;
+
+    server {
+        listen 443 ssl;
+        server_name example.com;
+
+        ssl_certificate     /etc/ssl/certs/example.com.pem;
+        ssl_certificate_key /etc/ssl/private/example.com.key;
+
+        ssl_stapling off;
+    }
+}

--- a/tests/plugins/simply/ssl_stapling_without_resolver/ssl_stapling_file_fp.conf
+++ b/tests/plugins/simply/ssl_stapling_without_resolver/ssl_stapling_file_fp.conf
@@ -1,0 +1,11 @@
+server {
+    listen 443 ssl;
+    server_name example.com;
+
+    ssl_certificate     /etc/ssl/certs/example.com.pem;
+    ssl_certificate_key /etc/ssl/private/example.com.key;
+
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    ssl_stapling_file /etc/ssl/ocsp/example.com.der;
+}

--- a/tests/plugins/simply/ssl_stapling_without_resolver/stapling_off_fp.conf
+++ b/tests/plugins/simply/ssl_stapling_without_resolver/stapling_off_fp.conf
@@ -1,0 +1,9 @@
+server {
+    listen 443 ssl;
+    server_name example.com;
+
+    ssl_certificate     /etc/ssl/certs/example.com.pem;
+    ssl_certificate_key /etc/ssl/private/example.com.key;
+
+    ssl_stapling off;
+}


### PR DESCRIPTION
## Summary

- New plugin `ssl_stapling_without_resolver`: flags SSL servers where `ssl_stapling on` is in effect (directly or inherited from `http {}`) but no `resolver` is reachable in scope. Without a resolver nginx silently disables OCSP stapling at startup — clients fall back to their own OCSP requests, adding handshake latency.
- Fixes one gap in the upstream reference implementation: exempts servers that set `ssl_stapling_file` (a pre-loaded OCSP response removes the need for a resolver entirely).
- 8 test fixtures: 2 true-positive cases (`no_resolver.conf`, `inherited_from_http.conf`) and 6 false-positive guards (resolver in server, resolver in http, stapling off, http-only server, `ssl_stapling_file` present, server overrides http-level `on` with `off`).
- Plugin doc, mkdocs nav entry, and README/index list updated.

## Test plan

- [ ] `uv run pytest tests/plugins/test_simply.py -k ssl_stapling` — all 8 cases pass
- [ ] `uv run pytest` — full suite (577 tests) passes with no regressions