### PR TITLE
Release 0.3.0

### DIFF
--- a/gixy/__init__.py
+++ b/gixy/__init__.py
@@ -2,4 +2,4 @@
 
 from gixy.core import severity
 
-version = "0.2.0"
+version = "0.3.0"


### PR DESCRIPTION
## Summary

- Bump version to `0.3.0`

## Changes since v0.2.0

- New plugin: `ssl_stapling_without_resolver` — flags SSL servers where `ssl_stapling on` is effective but no `resolver` is reachable in scope, causing OCSP stapling to silently fail at runtime (#28)