### PR TITLE
fix(manager): register if-block regex captures in prepopulate passes

### DIFF
--- a/gixy/core/manager.py
+++ b/gixy/core/manager.py
@@ -15,6 +15,7 @@ from gixy.directives.directive import (
     SetByLuaDirective,
     SetDirective,
 )
+from gixy.core.regexp import Regexp
 from gixy.parser.nginx_parser import NginxParser
 
 # Directives that register a named variable visible throughout their enclosing
@@ -105,6 +106,18 @@ class Manager(object):
                 if "document_root" not in context.variables["name"]:
                     context.add_var("document_root", builtins.fake_var("document_root"))
             elif directive.is_block and not directive.self_context:
+                if directive.provide_variables:
+                    value = getattr(directive, 'value', None)
+                    if value:
+                        try:
+                            for name in Regexp(value).groups.keys():
+                                if isinstance(name, str):
+                                    if name not in context.variables["name"]:
+                                        context.add_var(name, builtins.fake_var(name))
+                                elif name != 0 and name not in context.variables["index"]:
+                                    context.add_var(name, builtins.fake_var(str(name)))
+                        except Exception:
+                            pass
                 self._prepopulate_scope_var_names(directive.children)
 
     def _prepopulate_scope_var_values(self, tree):
@@ -114,6 +127,9 @@ class Manager(object):
                 for var in directive.variables:
                     context.add_var(var.name, var)
             elif directive.is_block and not directive.self_context:
+                if directive.provide_variables:
+                    for var in directive.variables:
+                        context.add_var(var.name, var)
                 self._prepopulate_scope_var_values(directive.children)
 
     def _update_variables(self, directive):

--- a/tests/core/test_manager.py
+++ b/tests/core/test_manager.py
@@ -122,6 +122,199 @@ http { server {
     assert any('LocalOnly' in r.getMessage() for r in _missing(caplog))
 
 
+# ---------------------------------------------------------------------------
+# Named capture groups from regex `if` blocks (issue #111)
+# ---------------------------------------------------------------------------
+# nginx supports three named-group syntaxes via PCRE:
+#   (?P<name>...)  — Python/PCRE8 style
+#   (?<name>...)   — Perl/PCRE style
+#   (?'name'...)   — PCRE7 style
+# Variables produced by these captures must be visible to:
+#   • set directives inside the if block
+#   • set directives after  the if block at the same scope level
+#   • set directives before the if block at the same scope level
+# All four regex operands are tested: ~  ~*  !~  !~*
+
+def test_if_regex_named_capture_set_inside_python_style(caplog):
+    # Basic case from issue #111: (?P<name>...) syntax, set inside the if block.
+    _audit("""
+http { server {
+    server_name example.com;
+    if ($http_referer ~ "^https?://example\\.com(?P<path>.*)") {
+        set $normalised_referrer $path;
+    }
+} }
+""", caplog)
+    assert _missing(caplog) == []
+
+
+def test_if_regex_named_capture_set_inside_nginx_style(caplog):
+    # Perl/nginx (?<name>...) syntax, set inside the if block.
+    _audit("""
+http { server {
+    if ($host ~ "^(?<subdomain>[^.]+)\\.example\\.com$") {
+        set $sub $subdomain;
+    }
+} }
+""", caplog)
+    assert _missing(caplog) == []
+
+
+def test_if_regex_named_capture_set_inside_pcre7_style(caplog):
+    # PCRE7 (?'name'...) syntax, set inside the if block.
+    _audit("""
+http { server {
+    if ($host ~ "^(?'subdomain'[^.]+)\\.example\\.com$") {
+        set $sub $subdomain;
+    }
+} }
+""", caplog)
+    assert _missing(caplog) == []
+
+
+def test_if_regex_named_capture_case_insensitive(caplog):
+    # ~* operator: case-insensitive named captures.
+    _audit("""
+http { server {
+    if ($http_referer ~* "^https?://example\\.com(?P<path>.*)") {
+        set $r $path;
+    }
+} }
+""", caplog)
+    assert _missing(caplog) == []
+
+
+def test_if_regex_named_capture_negative_match(caplog):
+    # !~ operator: named captures are registered even when the if body runs on
+    # non-match (nginx still exposes the group variables, set to empty string).
+    _audit("""
+http { server {
+    if ($http_referer !~ "^https?://example\\.com(?P<path>.*)") {
+        set $r $path;
+    }
+} }
+""", caplog)
+    assert _missing(caplog) == []
+
+
+def test_if_regex_named_capture_negative_case_insensitive(caplog):
+    # !~* operator.
+    _audit("""
+http { server {
+    if ($http_referer !~* "^https?://example\\.com(?P<path>.*)") {
+        set $r $path;
+    }
+} }
+""", caplog)
+    assert _missing(caplog) == []
+
+
+def test_if_regex_named_capture_set_after_same_level(caplog):
+    # set appears *after* the if block at the same scope level.
+    _audit("""
+http { server {
+    if ($http_referer ~ "^https?://example\\.com(?P<path>.*)") { }
+    set $normalised_referrer $path;
+} }
+""", caplog)
+    assert _missing(caplog) == []
+
+
+def test_if_regex_named_capture_set_before_same_level(caplog):
+    # set appears *before* the if block at the same scope level.
+    # Requires the names pre-pass to register capture names before values are
+    # compiled, otherwise compile_script sees $path as unknown.
+    _audit("""
+http { server {
+    set $normalised_referrer $path;
+    if ($http_referer ~ "^https?://example\\.com(?P<path>.*)") { }
+} }
+""", caplog)
+    assert _missing(caplog) == []
+
+
+def test_if_regex_multiple_named_captures(caplog):
+    # Multiple named captures in a single regex, all used.
+    _audit("""
+http { server {
+    if ($request_uri ~ "^/(?P<section>[^/]+)/(?P<id>[0-9]+)$") {
+        set $sec $section;
+        set $item_id $id;
+    }
+} }
+""", caplog)
+    assert _missing(caplog) == []
+
+
+def test_if_regex_nested_named_captures(caplog):
+    # Nested if blocks: outer capture visible inside inner block and to siblings;
+    # inner capture visible inside its own block.
+    _audit("""
+http { server {
+    if ($request_uri ~ "^/(?P<section>[^/]+)/") {
+        if ($http_host ~ "^(?P<subdomain>[^.]+)\\.example\\.com$") {
+            set $combo "$section-$subdomain";
+        }
+        set $s $section;
+    }
+} }
+""", caplog)
+    assert _missing(caplog) == []
+
+
+def test_if_regex_named_capture_custom_set_var_in_condition(caplog):
+    # The variable being matched in the if condition is itself a set variable.
+    # The set appears before the if, so both the matched variable and the
+    # capture must be resolvable.
+    _audit("""
+http { server {
+    set $myvar "hello-world";
+    if ($myvar ~ "^(?P<prefix>[^-]+)-") {
+        set $captured $prefix;
+    }
+} }
+""", caplog)
+    assert _missing(caplog) == []
+
+
+def test_if_regex_named_capture_custom_set_var_after_condition(caplog):
+    # The variable being matched is a set variable declared *after* the if block.
+    _audit("""
+http { server {
+    if ($myvar ~ "^(?P<prefix>[^-]+)-") {
+        set $captured $prefix;
+    }
+    set $myvar "hello-world";
+} }
+""", caplog)
+    assert _missing(caplog) == []
+
+
+def test_if_regex_named_and_numeric_captures_coexist(caplog):
+    # Named and unnamed (numeric) captures in the same regex.
+    # $section is a named capture; $2 is numeric — both must resolve.
+    _audit("""
+http { server {
+    if ($request_uri ~ "^/(?P<section>[^/]+)/([0-9]+)$") {
+        set $s $section;
+        set $num $2;
+    }
+} }
+""", caplog)
+    assert _missing(caplog) == []
+
+
+def test_if_regex_numeric_capture_set_before_same_level(caplog):
+    # Numeric capture used in a set that appears *before* the if block.
+    _audit("""
+http { server {
+    set $num $1;
+    if ($request_uri ~ "^/([0-9]+)$") { }
+} }
+""", caplog)
+    assert _missing(caplog) == []
+
+
 def test_prepopulated_map_taint_still_fires_security_check():
     # map-after-server routes tainted $uri through $target; http_splitting must still fire
     config = """


### PR DESCRIPTION
Named and numeric capture groups from regex `if`-blocks were invisible to `set` directives in the same scope, producing spurious `Can't find variable` warnings for valid configs.

## Changes

`_prepopulate_scope_var_names` and `_prepopulate_scope_var_values` now register capture variables from any `provide_variables` block before recursing into its children. The names pass uses a fresh `Regexp` (not the `cached_property`) to avoid prematurely caching `boundary` before dependent `set` values are in context.

This covers `set` directives placed **inside**, **after**, or **before** the `if`-block at the same scope level.

## Tests

New cases in `tests/core/test_manager.py`:
- All three PCRE named-group syntaxes: `(?P<name>...)`, `(?<name>...)`, `(?'name'...)`
- All four regex operands: `~`, `~*`, `!~`, `!~*`
- All placement variants: set inside / after / before the if-block
- Multiple captures, nested if-blocks, mixed named+numeric captures, custom `set` variables in conditions
