### PR TITLE
fix(scanner): handle INFORMATION severity in sort and filter chips

### DIFF
--- a/docs/extra/gixy-scan.js
+++ b/docs/extra/gixy-scan.js
@@ -15,7 +15,7 @@
 
   const WHEEL_URL = new URL("/extra/gixy_next-0.0.0-py3-none-any.whl", window.location.origin).href;
 
-  const severityOrder = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO", "UNKNOWN"];
+  const severityOrder = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFORMATION", "UNKNOWN"];
 
   const state = {
     initPromise: null,
@@ -157,7 +157,7 @@ server {
 
     summaryEl.appendChild(document.createTextNode(`Findings: ${all.length}`));
 
-    for (const sev of ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"]) {
+    for (const sev of ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFORMATION"]) {
       const n = counts.get(sev) || 0;
       if (!n) continue;
 


### PR DESCRIPTION
Gixy emits severity "INFORMATION" (per gixy/core/severity.py), but the in-browser scanner JS expected "INFO". As a result, INFORMATION findings fell through to severityOrder.indexOf() === -1, sorting them above CRITICAL, and the chip-render loop skipped emitting a filter for them.

Use "INFORMATION" consistently in both severityOrder and the chip loop.