### PR TITLE
Style cleanup for CVE plugins + (*VERB) capture-walker fix

### DIFF
--- a/gixy/plugins/overlapping_captures.py
+++ b/gixy/plugins/overlapping_captures.py
@@ -13,38 +13,37 @@ class overlapping_captures(Plugin):
     """
 
     summary = (
-        "Rewrite with overlapping captures in redirect/args context — heap overflow "
-        "(CVE-2026-9256)."
+        "Rewrite with overlapping captures in redirect/args context causes "
+        "heap overflow (CVE-2026-9256)."
     )
     severity = gixy.severity.INFORMATION
     description = (
-        "CVE-2026-9256 is a bug in nginx itself: when a `rewrite` regex contains overlapping "
-        "(nested) captures and its replacement references multiple of those captures by "
-        "`$N` in a redirect or arguments context, nginx allocates a buffer sized for the "
-        "raw capture bytes but writes URI-escaped bytes — which can be several times "
-        "longer — overflowing the buffer. On unpatched nginx (< 1.30.2/1.31.1) a crafted "
-        "request triggers a heap buffer overflow in the worker process. The only real fix "
-        "is upgrading nginx. As a workaround, remove the `$N` references from the "
-        "replacement: convert the captures to named ones (`(?<name>...)`) and reference "
-        "them by `$name` instead of `$N`. PCRE numbers named captures alongside unnamed "
-        "ones, so switching the regex syntax alone is not enough — the replacement must "
-        "stop using `$N`. Because Gixy-Next cannot determine the nginx version from the "
-        "configuration, any matching pattern is reported as INFORMATION — if you are "
-        "already on a patched version, no action is required."
+        "CVE-2026-9256 is a bug in nginx itself: when a `rewrite` regex contains "
+        "overlapping (nested) captures and its replacement references multiple of "
+        "those captures by `$N` in a redirect or arguments context, nginx allocates "
+        "a buffer sized for the raw capture bytes but writes URI-escaped bytes (which "
+        "can be several times longer), overflowing the buffer. On unpatched nginx "
+        "(< 1.30.2/1.31.1) a crafted request triggers a heap buffer overflow in the "
+        "worker process. The only real fix is upgrading nginx. As a workaround, "
+        "remove the `$N` references from the replacement: convert the captures to "
+        "named ones (`(?<name>...)`) and reference them by `$name` instead of `$N`. "
+        "PCRE numbers named captures alongside unnamed ones, so switching the regex "
+        "syntax alone is not enough; the replacement must stop using `$N`. Because "
+        "Gixy-Next cannot determine the nginx version from the configuration, any "
+        "matching pattern is reported as INFORMATION. If you are already on a "
+        "patched version, no action is required."
     )
     help_url = "https://gixy.io/plugins/overlapping_captures/"
     directives = ["rewrite"]
 
     _REDIRECT_FLAGS = frozenset(("redirect", "permanent"))
-    # A replacement starting with one of these prefixes triggers an implicit
-    # redirect (regex->redirect = 1) without any explicit redirect/permanent
-    # flag — see ngx_http_rewrite_module.c:354-361. `$scheme://` also does,
-    # but a `$scheme` reference is a variable and we already bail out then.
+    # An `http://` / `https://` prefix is an implicit redirect, even
+    # without a `redirect`/`permanent` flag.
     _IMPLICIT_REDIRECT_PREFIXES = ("http://", "https://")
-    # nginx only parses single-digit `$1`..`$9` (ngx_http_script.c:480-485);
-    # `$10` is `$1` followed by literal `0`.
+    # nginx parses only single-digit `$1`..`$9`; `$10` is `$1` followed
+    # by literal `0`.
     _NUMERIC_CAPTURE = re.compile(r"\$([1-9])")
-    # nginx variable refs (`$name` / `${name}`) — never a numeric capture,
+    # nginx variable refs (`$name` / `${name}`); never a numeric capture
     # since the unbraced form requires a non-digit first character.
     _NGINX_VARIABLE = re.compile(r"\$[A-Za-z_]\w*|\$\{[^}]+\}")
 
@@ -56,41 +55,32 @@ class overlapping_captures(Plugin):
         replacement = directive.args[1]
         flag = directive.args[2].lower() if len(directive.args) > 2 else ""
 
-        # nginx strips a sole trailing `?` from the replacement (it means
-        # "drop the original arguments"), so a trailing-only `?` never
-        # enters runtime args mode — see ngx_http_rewrite_module.c:343-346.
+        # nginx strips a sole trailing `?` from the replacement (it
+        # means "drop the original arguments"), so a trailing-only `?`
+        # never enters runtime args mode.
         if replacement.endswith("?"):
             replacement = replacement[:-1]
 
-        # A replacement that contains any `$name` / `${name}` variable goes
-        # through nginx's lengths != NULL length-calc path, which uses
-        # per-capture length code that is not vulnerable.
+        # A replacement containing any `$name` / `${name}` variable
+        # routes through the safe per-capture length-calc path.
         if self._NGINX_VARIABLE.search(replacement):
             return
 
-        # Redirect mode (e->quote = 1 at runtime) is entered either by an
-        # explicit `redirect`/`permanent` flag, or implicitly when the
-        # replacement starts with `http://` or `https://`. Either path
-        # causes every `$N` in the replacement to be URI-escaped on output.
         is_redirect = (
             flag in self._REDIRECT_FLAGS
             or replacement.startswith(self._IMPLICIT_REDIRECT_PREFIXES)
         )
 
-        # A duplicate `$N` reference anywhere in the replacement sets
-        # sc.dup_capture = 1, which forces nginx onto its safe length-calc
-        # path (ngx_http_script.c:486-488; ngx_http_rewrite_module.c:408).
+        # A duplicate `$N` reference anywhere in the replacement forces
+        # nginx onto its safe length-calc path.
         all_refs = self._NUMERIC_CAPTURE.findall(replacement)
         if len(all_refs) != len(set(all_refs)):
             return
 
-        # Which `$N` references actually run in escape mode?
-        #   - redirect:  every `$N` (e->quote = 1 covers the whole buffer).
-        #   - non-redirect: only `$N`s after the first `?`, where
-        #     ngx_http_script_start_args_code sets e->is_args = 1. Refs
-        #     before the `?` are written raw and cannot overflow on their
-        #     own — a single-escaped capture stays within the buggy
-        #     `escape(URI)` budget.
+        # Which `$N` references run in escape mode? On a redirect, all
+        # of them. Otherwise only those after the first `?`; refs before
+        # are written raw and a lone escaped capture stays within the
+        # buggy length budget.
         if is_redirect:
             escaped_refs = all_refs
         else:
@@ -111,23 +101,17 @@ class overlapping_captures(Plugin):
             reason=(
                 "A `rewrite` regex with overlapping captures and a replacement that "
                 "references multiple `$N` captures runs in redirect or arguments "
-                "context — on unpatched nginx (< 1.30.2/1.31.1) this causes a heap "
+                "context. On unpatched nginx (< 1.30.2/1.31.1) this causes a heap "
                 "buffer overflow (CVE-2026-9256)."
             ),
         )
 
-    @classmethod
-    def _referenced_captures_overlap(cls, regex, referenced):
-        """Return True iff any pair of *referenced* capture groups is
-        syntactically nested (one is an ancestor of the other).
-
-        PCRE numbers named and unnamed captures into the same sequence,
-        so `$1` works for `(?<name>...)` just as for `(...)`. Sibling
-        capture pairs (e.g. `((.*))/((.*))` with `$1$3`) are not
-        reported — their byte ranges do not overlap.
-        """
-        parent, total = cls._capture_parent_map(regex)
-        ancestors = {g: cls._chain_ancestors(parent, g) for g in parent}
+    def _referenced_captures_overlap(self, regex, referenced):
+        # True iff any pair of referenced groups is syntactically nested
+        # (one is an ancestor of the other). Sibling pairs like
+        # `((.*))/((.*))` with `$1$3` are not reported.
+        parent, total = self._capture_parent_map(regex)
+        ancestors = {g: self._chain_ancestors(parent, g) for g in parent}
         refs = sorted(g for g in referenced if g <= total)
         for idx, g1 in enumerate(refs):
             anc1 = ancestors.get(g1, set())
@@ -136,8 +120,7 @@ class overlapping_captures(Plugin):
                     return True
         return False
 
-    @staticmethod
-    def _chain_ancestors(parent, g):
+    def _chain_ancestors(self, parent, g):
         chain = set()
         p = parent.get(g)
         while p is not None:
@@ -145,13 +128,11 @@ class overlapping_captures(Plugin):
             p = parent.get(p)
         return chain
 
-    @classmethod
-    def _capture_parent_map(cls, regex):
-        """Walk `regex` once and return (parent, total) where parent maps
-        each capturing group number to its nearest capturing ancestor (or
-        None at top level), and total is the number of capturing groups.
-        Captures are numbered in declaration order, named or unnamed.
-        """
+    def _capture_parent_map(self, regex):
+        # Walk `regex` once. Return (parent, total) where parent maps each
+        # capturing group number to its nearest capturing ancestor (or
+        # None at top level), and total is the number of capturing groups.
+        # Groups are numbered in declaration order, named or unnamed.
         parent = {}
         stack = []   # cap_num if capturing else None
         cap = 0
@@ -163,10 +144,10 @@ class overlapping_captures(Plugin):
                 i += 2
                 continue
             if c == "[":
-                i = cls._skip_char_class(regex, i)
+                i = self._skip_char_class(regex, i)
                 continue
             if c == "(":
-                if cls._is_capturing_paren(regex, i):
+                if self._is_capturing_paren(regex, i):
                     cap += 1
                     parent[cap] = next(
                         (x for x in reversed(stack) if x is not None), None
@@ -179,9 +160,8 @@ class overlapping_captures(Plugin):
             i += 1
         return parent, cap
 
-    @staticmethod
-    def _skip_char_class(regex, i):
-        """Advance past a `[...]` character class, honoring internal escapes."""
+    def _skip_char_class(self, regex, i):
+        # Advance past a `[...]` character class, honoring escapes.
         n = len(regex)
         i += 1
         while i < n:
@@ -193,15 +173,13 @@ class overlapping_captures(Plugin):
             i += 1
         return i
 
-    @staticmethod
-    def _is_capturing_paren(regex, i):
-        """Return True iff regex[i] starts a capturing group (named or
-        unnamed). Non-capturing groups, lookarounds, atomic groups, inline
-        flags, comments, and backreferences/recursion return False.
-        """
+    def _is_capturing_paren(self, regex, i):
+        # True iff regex[i] starts a capturing group (named or unnamed).
+        # Non-capturing groups, lookarounds, atomic groups, inline flags,
+        # comments, and named backreferences/recursion return False.
         n = len(regex)
         if i + 1 >= n or regex[i + 1] != "?":
-            return True  # plain `(` — unnamed capture
+            return True  # plain `(`: unnamed capture
         if i + 2 >= n:
             return False
         c2 = regex[i + 2]

--- a/gixy/plugins/overlapping_captures.py
+++ b/gixy/plugins/overlapping_captures.py
@@ -176,9 +176,15 @@ class overlapping_captures(Plugin):
     def _is_capturing_paren(self, regex, i):
         # True iff regex[i] starts a capturing group (named or unnamed).
         # Non-capturing groups, lookarounds, atomic groups, inline flags,
-        # comments, and named backreferences/recursion return False.
+        # comments, named backreferences/recursion, and PCRE verbs return
+        # False.
         n = len(regex)
-        if i + 1 >= n or regex[i + 1] != "?":
+        if i + 1 >= n:
+            return True
+        nxt = regex[i + 1]
+        if nxt == "*":
+            return False  # PCRE verb: `(*UTF)`, `(*MARK:name)`, `(*COMMIT)`, etc.
+        if nxt != "?":
             return True  # plain `(`: unnamed capture
         if i + 2 >= n:
             return False

--- a/gixy/plugins/unnamed_groups.py
+++ b/gixy/plugins/unnamed_groups.py
@@ -14,46 +14,41 @@ class unnamed_groups(Plugin):
     """
 
     summary = (
-        "Rewrite with '?' followed by set/if referencing $N — heap overflow "
-        "(CVE-2026-42945)."
+        "Rewrite with '?' followed by set/if referencing $N causes heap "
+        "overflow (CVE-2026-42945)."
     )
     severity = gixy.severity.INFORMATION
     description = (
         "CVE-2026-42945 is a bug in nginx itself: a `rewrite` replacement containing "
         "`?` sets an args-escaping flag on the script engine that is not cleared "
         "afterwards. On unpatched nginx (< 1.30.1/1.31.0), a subsequent `set $var $N` "
-        "or `if` that reads a numeric capture ($1, $2, …) allocates a buffer sized "
+        "or `if` that reads a numeric capture ($1, $2, ...) allocates a buffer sized "
         "for raw bytes but writes URI-escaped bytes, causing a heap buffer overflow. "
         "The only real fix is upgrading nginx. As a workaround, remove the `$N` "
         "reference from the affected `set` or `if`: convert the regex's unnamed "
         "capture to a named one (`(?<name>...)`) and reference it by `$name`. PCRE "
         "numbers named captures alongside unnamed ones, so renaming the regex group "
         "alone is not enough. Because Gixy-Next cannot determine the nginx version "
-        "from the configuration, any matching pattern is reported as INFORMATION — "
-        "if you are already on a patched version, no action is required."
+        "from the configuration, any matching pattern is reported as INFORMATION. "
+        "If you are already on a patched version, no action is required."
     )
     help_url = "https://gixy.io/plugins/unnamed_groups/"
     directives = ["rewrite"]
 
     _TERMINATING_FLAGS = frozenset(("last", "break", "redirect", "permanent"))
-    # A replacement starting with one of these triggers an implicit redirect
-    # (regex->redirect = 1, last = 1) in ngx_http_rewrite_module.c:354-361,
-    # which appends a NULL opcode after the rewrite — the engine halts on match.
+    # An `http://` / `https://` / `$scheme` prefix on the replacement is
+    # an implicit redirect, which halts the engine on match.
     _REDIRECT_PREFIXES = ("http://", "https://", "$scheme")
-    # File-test operators that take a complex value (compiled via
-    # ngx_http_rewrite_value → complex_value_code at line 801).
     _IF_FILE_OPS = frozenset(("-f", "-d", "-e", "-x", "!-f", "!-d", "!-e", "!-x"))
-    # nginx only parses single-digit `$1`..`$9` (ngx_http_script.c:480-485).
+    # nginx parses only single-digit `$1`..`$9`.
     _NUMERIC_CAPTURE = re.compile(r"\$[1-9]")
 
     def audit(self, directive):
         if len(directive.args) < 2 or "?" not in directive.args[1]:
             return
 
-        # If the rewrite itself halts on match (explicit terminating flag or
-        # an implicit redirect via http:// / https:// / $scheme prefix), the
-        # NULL opcode appended after `regex_end_code` stops the engine before
-        # any subsequent directive in this codes array can execute.
+        # A rewrite that halts on match cannot be followed by an
+        # observable `set`/`if` execution.
         if self._rewrite_is_terminator(directive):
             return
 
@@ -67,9 +62,8 @@ class unnamed_groups(Plugin):
                     continue
                 if not past_self:
                     continue
-                # `return` and standalone `break;` write
-                # `e->ip = ngx_http_script_exit` unconditionally —
-                # everything after them in the bytecode never runs.
+                # `return` and standalone `break;` unconditionally halt
+                # the rewrite-phase engine; nothing after them runs.
                 if self._unconditional_terminator(sibling):
                     return
                 if self._has_vulnerable_complex_value(sibling):
@@ -78,70 +72,44 @@ class unnamed_groups(Plugin):
                         reason=(
                             "A `rewrite` with `?` in its replacement is followed "
                             "by a `set` or `if` directive whose value references "
-                            "a numeric capture group — on unpatched nginx "
+                            "a numeric capture group. On unpatched nginx "
                             "(< 1.30.1/1.31.0) this causes a heap buffer overflow "
                             "(CVE-2026-42945)."
                         ),
                     )
                     return
-            # Walk outward through grouping blocks (if / include / map / geo,
-            # all `self_context = False`) but stop at real scope boundaries.
-            # The script engine's args flag persists across `if` exit, so a
-            # `set $N` placed after the enclosing if-block is still affected.
-            if not getattr(parent, "is_block", False) or getattr(parent, "self_context", True):
+            # Walk outward through grouping blocks (if/include/map/geo)
+            # but stop at real scope boundaries. The args flag persists
+            # across an if-block exit, so a `set $N` placed after the
+            # enclosing if-block is still affected.
+            if not parent.is_block or parent.self_context:
                 break
             node = parent
             parent = parent.parent
 
-    @classmethod
-    def _rewrite_is_terminator(cls, directive):
-        """The rewrite halts the engine on match: explicit flag, or an
-        implicit redirect from `http://` / `https://` / `$scheme` prefix
-        on the replacement (ngx_http_rewrite_module.c:354-361 / 425-432)."""
-        if len(directive.args) > 2 and directive.args[2].lower() in cls._TERMINATING_FLAGS:
+    def _rewrite_is_terminator(self, directive):
+        if len(directive.args) > 2 and directive.args[2].lower() in self._TERMINATING_FLAGS:
             return True
-        return directive.args[1].startswith(cls._REDIRECT_PREFIXES)
+        return directive.args[1].startswith(self._REDIRECT_PREFIXES)
 
-    @staticmethod
-    def _unconditional_terminator(node):
-        """Halts the rewrite-phase engine on every execution, regardless of
-        any condition. Used to stop the sibling walk — anything after one
-        of these never runs.
-
-        A subsequent `rewrite` with a terminating flag or implicit redirect
-        is intentionally NOT included here: its halt is conditional on the
-        regex matching, which can't be reasoned about statically.
-        """
+    def _unconditional_terminator(self, node):
         if node.name == "return":
             return True
-        if node.name == "break" and not getattr(node, "is_block", False):
+        return node.name == "break" and not node.is_block
+
+    def _has_vulnerable_complex_value(self, node):
+        if self._direct_complex_value(node):
             return True
+        if node.is_block and not node.self_context:
+            return any(self._has_vulnerable_complex_value(child) for child in node.children)
         return False
 
-    @classmethod
-    def _has_vulnerable_complex_value(cls, node):
-        """True if this node (or, in a grouping block, any descendant) emits
-        a `ngx_http_script_complex_value_code` whose source contains a
-        numeric capture reference — that opcode is the runtime trigger of
-        CVE-2026-42945, generated by:
-
-        * `set $var VALUE`                         (rewrite_module.c:934)
-        * `if ($var = VALUE)` / `if ($var != VALUE)`  (lines 718, 735)
-        * `if (-f VALUE)` and other file operators (line 801)
-        """
-        if cls._direct_complex_value(node):
-            return True
-        if getattr(node, "is_block", False) and not getattr(node, "self_context", True):
-            return any(cls._has_vulnerable_complex_value(child) for child in node.children)
-        return False
-
-    @classmethod
-    def _direct_complex_value(cls, node):
+    def _direct_complex_value(self, node):
         if node.name == "set" and len(node.args) >= 2:
-            return bool(cls._NUMERIC_CAPTURE.search(node.args[1]))
+            return bool(self._NUMERIC_CAPTURE.search(node.args[1]))
         if node.name == "if":
             if len(node.args) >= 3 and node.args[1] in ("=", "!="):
-                return bool(cls._NUMERIC_CAPTURE.search(node.args[2]))
-            if len(node.args) >= 2 and node.args[0] in cls._IF_FILE_OPS:
-                return bool(cls._NUMERIC_CAPTURE.search(node.args[1]))
+                return bool(self._NUMERIC_CAPTURE.search(node.args[2]))
+            if len(node.args) >= 2 and node.args[0] in self._IF_FILE_OPS:
+                return bool(self._NUMERIC_CAPTURE.search(node.args[1]))
         return False

--- a/tests/plugins/simply/overlapping_captures/overlapping_captures_pcre_verb.conf
+++ b/tests/plugins/simply/overlapping_captures/overlapping_captures_pcre_verb.conf
@@ -1,0 +1,10 @@
+# PCRE `(*VERB)` markers at the start of a regex (`(*UTF)`, `(*MARK:...)`,
+# `(*COMMIT)`, etc.) are accepted by nginx but are not capturing groups.
+# The walker must skip them so that `$1`/`$2` map to the real captures.
+# Here the real overlap is captures 1 and 2 (`((.*))`), referenced as
+# `$1$2` in an implicit-redirect replacement.
+server {
+    location / {
+        rewrite (*UTF)((.*))$ http://example.com/$1$2;
+    }
+}

--- a/tests/plugins/simply/overlapping_captures/overlapping_captures_pcre_verb_fp.conf
+++ b/tests/plugins/simply/overlapping_captures/overlapping_captures_pcre_verb_fp.conf
@@ -1,0 +1,9 @@
+# If a `(*VERB)` is mistakenly counted as a capture, the walker's capture
+# numbering shifts and sibling captures can look nested. `(*UTF)/(.*)/(.*)$`
+# has two top-level sibling captures and `$1$2` does not overlap; the
+# plugin must not flag this.
+server {
+    location / {
+        rewrite (*UTF)/(.*)/(.*)$ http://example.com/$1$2;
+    }
+}


### PR DESCRIPTION
Follow-up to #38 / #39.

- Style: bring `unnamed_groups.py` and `overlapping_captures.py` in line with the voice of the other plugins in `gixy/plugins/` (em-dashes → plain punctuation, drop the nginx C source line refs from comments, convert `@classmethod`/`@staticmethod` helpers to instance methods, drop defensive `getattr()`, trim helper docstrings). No behavior change.
- Fix: `overlapping_captures._is_capturing_paren` was counting PCRE `(*VERB)` markers (`(*UTF)`, `(*MARK:name)`, `(*COMMIT)`, …) as real capturing groups. Verified against nginx 1.31.1 that a config like `rewrite (*UTF)((.*))$ http://x/$1$2;` compiles, so this was a real (if exotic) false negative for CVE-2026-9256. Positive + FP fixtures added.

## Test plan
- [x] `pytest tests -n auto` → 653 passed (651 before, +2 new fixtures)
- [x] Positive fixture verified to fail on the parent commit and pass on the fix commit