### PR TITLE
stale_dns_cache: handle bracketed IPv6 addresses

### DIFF
--- a/gixy/plugins/stale_dns_cache.py
+++ b/gixy/plugins/stale_dns_cache.py
@@ -65,7 +65,7 @@ class stale_dns_cache(Plugin):
             else:
                 break
 
-        if is_ipv6(parsed_host, False) or is_ipv4(parsed_host, False):
+        if is_ipv6(parsed_host) or is_ipv4(parsed_host, False):
             return
 
         h = parsed_host.lower().rstrip(".")
@@ -116,7 +116,7 @@ class stale_dns_cache(Plugin):
                         continue
 
                     parsed_upstream_host = parsed_upstream_server.group("host")
-                    if is_ipv6(parsed_upstream_host, False) or is_ipv4(
+                    if is_ipv6(parsed_upstream_host) or is_ipv4(
                         parsed_upstream_host, False
                     ):
                         continue

--- a/tests/plugins/simply/stale_dns_cache/block_proxy_pass_ipv6_literal_fp.conf
+++ b/tests/plugins/simply/stale_dns_cache/block_proxy_pass_ipv6_literal_fp.conf
@@ -1,0 +1,16 @@
+# Should NOT trigger: proxy_pass uses a bracketed IPv6 literal directly,
+# with or without a port.
+http {
+  server {
+    listen 80;
+    location /a {
+      proxy_pass http://[2001:db8::1]:8080;
+    }
+    location /b {
+      proxy_pass http://[::1]:8080;
+    }
+    location /c {
+      proxy_pass http://[2001:db8::1];
+    }
+  }
+}

--- a/tests/plugins/simply/stale_dns_cache/block_upstream_ipv6_no_port_fp.conf
+++ b/tests/plugins/simply/stale_dns_cache/block_upstream_ipv6_no_port_fp.conf
@@ -1,0 +1,13 @@
+# Should NOT trigger: upstream uses a bracketed IPv6 literal without a port.
+http {
+  upstream v6_service {
+    server [2001:db8::1];
+  }
+
+  server {
+    listen 80;
+    location / {
+      proxy_pass http://v6_service;
+    }
+  }
+}

--- a/tests/plugins/simply/stale_dns_cache/block_upstream_ipv6_servers_fp.conf
+++ b/tests/plugins/simply/stale_dns_cache/block_upstream_ipv6_servers_fp.conf
@@ -1,0 +1,19 @@
+# Should NOT trigger: upstream uses bracketed IPv6 literals; no DNS lookup
+# is involved at runtime. Mirrors the configuration from issue #41.
+http {
+  resolver 127.0.0.53;
+
+  upstream some_service {
+    server [::1]:8101;
+  }
+
+  server {
+    listen 80;
+    location / {
+      proxy_pass http://some_service;
+    }
+    location /api/socket.io/ {
+      proxy_pass http://some_service;
+    }
+  }
+}

--- a/tests/plugins/simply/stale_dns_cache/block_upstream_ipv6_uppercase_fp.conf
+++ b/tests/plugins/simply/stale_dns_cache/block_upstream_ipv6_uppercase_fp.conf
@@ -1,0 +1,13 @@
+# Should NOT trigger: bracketed IPv6 literals using uppercase hex digits.
+http {
+  upstream svc {
+    server [2001:DB8::DEAD:BEEF]:443;
+  }
+
+  server {
+    listen 80;
+    location / {
+      proxy_pass http://svc;
+    }
+  }
+}

--- a/tests/plugins/simply/stale_dns_cache/block_upstream_mixed_v4_v6_fp.conf
+++ b/tests/plugins/simply/stale_dns_cache/block_upstream_mixed_v4_v6_fp.conf
@@ -1,0 +1,15 @@
+# Should NOT trigger: upstream mixes IPv4 and bracketed IPv6 literals.
+http {
+  upstream mixed {
+    server 127.0.0.1:8080;
+    server [::1]:8080;
+    server [2001:db8::1]:8080;
+  }
+
+  server {
+    listen 80;
+    location / {
+      proxy_pass http://mixed;
+    }
+  }
+}

--- a/tests/plugins/simply/stale_dns_cache/tp_upstream_mixed_ipv6_and_hostname.conf
+++ b/tests/plugins/simply/stale_dns_cache/tp_upstream_mixed_ipv6_and_hostname.conf
@@ -1,0 +1,16 @@
+# Should TRIGGER: even though one server is a bracketed IPv6 literal, the
+# second is a real hostname without `resolve`, which is the classic stale
+# DNS cache scenario.
+http {
+  upstream mixed {
+    server [::1]:8080;
+    server backend.example.com:8080;
+  }
+
+  server {
+    listen 80;
+    location / {
+      proxy_pass http://mixed;
+    }
+  }
+}


### PR DESCRIPTION
The plugin called is_ipv6 with strip_brackets=False, so bracketed forms like [::1]:8101 from the parse_uri_re regex never matched IPv6 and were treated as hostnames. Both the upstream-server check and the direct proxy_pass check are affected.

Fixes #41.