### PR TITLE
return_bypasses_allow_deny: skip internally-reachable locations

### DIFF
--- a/gixy/plugins/return_bypasses_allow_deny.py
+++ b/gixy/plugins/return_bypasses_allow_deny.py
@@ -22,6 +22,35 @@ class return_bypasses_allow_deny(Plugin):
         super(return_bypasses_allow_deny, self).__init__(config)
         self._reported_parents = set()
 
+    @staticmethod
+    def _is_internal_only_location(node):
+        """True for locations only reachable via internal redirect.
+
+        Named locations (`location @name`) and locations carrying the
+        `internal` directive cannot be hit by an external request, so a
+        `return` inside them does not bypass the parent's allow/deny: any
+        client that ever reaches the return has already passed the access
+        phase of the originating location.
+        """
+        if getattr(node, "name", None) != "location":
+            return False
+        if getattr(node, "path", "").startswith("@"):
+            return True
+        return bool(getattr(node, "is_internal", False))
+
+    def _find_descendants_excluding_internal_locations(self, node, name):
+        result = []
+        for child in node.children:
+            if self._is_internal_only_location(child):
+                continue
+            if child.name == name:
+                result.append(child)
+            if getattr(child, "is_block", False):
+                result.extend(
+                    self._find_descendants_excluding_internal_locations(child, name)
+                )
+        return result
+
     def audit(self, directive):
         parent = directive.parent
 
@@ -33,10 +62,16 @@ class return_bypasses_allow_deny(Plugin):
             return
         self._reported_parents.add(key)
 
-        return_directive = list(parent.find_recursive("return"))
+        return_directive = self._find_descendants_excluding_internal_locations(
+            parent, "return"
+        )
         if return_directive:
-            all_allow_directives = list(parent.find_recursive("allow"))
-            all_deny_directives = list(parent.find_recursive("deny"))
+            all_allow_directives = (
+                self._find_descendants_excluding_internal_locations(parent, "allow")
+            )
+            all_deny_directives = (
+                self._find_descendants_excluding_internal_locations(parent, "deny")
+            )
             self.add_issue(
                 directive=[directive]
                 + return_directive

--- a/tests/plugins/simply/return_bypasses_allow_deny/return_in_internal_location_fp.conf
+++ b/tests/plugins/simply/return_bypasses_allow_deny/return_in_internal_location_fp.conf
@@ -1,0 +1,13 @@
+# Should NOT trigger: the return is inside a location marked `internal`,
+# so external requests cannot reach it directly. The parent's allow/deny
+# already apply to whatever originating location triggered the internal
+# redirect.
+server {
+  allow 127.0.0.1;
+  deny all;
+
+  location /cb {
+    internal;
+    return 200 "callback";
+  }
+}

--- a/tests/plugins/simply/return_bypasses_allow_deny/return_in_internal_location_with_self_allow_deny.conf
+++ b/tests/plugins/simply/return_bypasses_allow_deny/return_in_internal_location_with_self_allow_deny.conf
@@ -1,0 +1,8 @@
+# Should TRIGGER: when an internal-only location defines its own allow/deny,
+# the return in that same scope still bypasses them.
+location /cb {
+  internal;
+  allow 127.0.0.1;
+  deny all;
+  return 200 "callback";
+}

--- a/tests/plugins/simply/return_bypasses_allow_deny/return_in_named_location_fp.conf
+++ b/tests/plugins/simply/return_bypasses_allow_deny/return_in_named_location_fp.conf
@@ -1,0 +1,19 @@
+# Should NOT trigger: the return lives in a named location, which is only
+# reachable through an internal redirect (here via error_page). The server's
+# allow/deny were already enforced for the originating location before the
+# redirect happened. Mirrors the configuration from issue #40.
+server {
+  server_name example.com;
+
+  location @redirectToAuth2ProxyLogin {
+    return 307 https://auth.example.com/oauth2/start?rd=$scheme://$host$request_uri;
+  }
+
+  auth_request /oauth2/auth;
+  error_page 401 = @redirectToAuth2ProxyLogin;
+  satisfy any;
+
+  allow 127.0.0.1;
+  allow ::1;
+  deny all;
+}

--- a/tests/plugins/simply/return_bypasses_allow_deny/return_in_named_location_with_self_allow_deny.conf
+++ b/tests/plugins/simply/return_bypasses_allow_deny/return_in_named_location_with_self_allow_deny.conf
@@ -1,0 +1,8 @@
+# Should TRIGGER: when a named location defines its own allow/deny, the
+# return in that same scope still bypasses them, because the return is
+# evaluated in the rewrite phase before the access phase.
+location @internal_handler {
+  allow 127.0.0.1;
+  deny all;
+  return 200 "secret";
+}

--- a/tests/plugins/simply/return_bypasses_allow_deny/return_in_regular_child_location.conf
+++ b/tests/plugins/simply/return_bypasses_allow_deny/return_in_regular_child_location.conf
@@ -1,0 +1,12 @@
+# Should TRIGGER: the return is inside a regular child location, reachable
+# directly from the outside. The server-level allow/deny would normally
+# apply by inheritance, but the return is processed in the rewrite phase
+# and preempts the access phase.
+server {
+  allow 127.0.0.1;
+  deny all;
+
+  location /foo {
+    return 200 "hi";
+  }
+}


### PR DESCRIPTION
Named locations (location @name) and locations carrying the `internal` directive cannot be hit by external requests, so a `return` inside one does not bypass the parent's allow/deny -- the originating location's access phase already ran. The recursive scan now skips into those locations, while still flagging an allow/deny + return pair living in the same internal-only scope.

Fixes #40.