### PR TITLE
status_page_exposed: honor auth_request, auth_basic, and internal

### DIFF
--- a/gixy/plugins/status_page_exposed.py
+++ b/gixy/plugins/status_page_exposed.py
@@ -27,8 +27,51 @@ class status_page_exposed(Plugin):
                 )
         return False
 
+    @staticmethod
+    def _resolve_inherited(scope, name):
+        """Return the effective value of an inheritable single-value directive.
+
+        Walks up from `scope` to the root. The first scope that declares the
+        directive wins (closest scope), matching nginx inheritance. If a scope
+        declares the directive more than once, the last occurrence is used.
+        Returns None when the directive is unset anywhere up the chain.
+        """
+        current = scope
+        while current:
+            matches = [
+                c
+                for c in current.children
+                if (c.name or "").lower() == name and c.args
+            ]
+            if matches:
+                return matches[-1].args[0].lower()
+            current = current.parent
+        return None
+
+    def _has_inherited_auth(self, directive):
+        """True if auth_request or auth_basic is enabled at or above this scope."""
+        for name in ("auth_request", "auth_basic"):
+            value = self._resolve_inherited(directive.parent, name)
+            if value is not None and value != "off":
+                return True
+        return False
+
+    @staticmethod
+    def _location_is_internal_only(directive):
+        """True if the directive is inside a `location` carrying `internal`."""
+        for parent in directive.parents:
+            if parent.name == "location":
+                return bool(getattr(parent, "is_internal", False))
+        return False
+
     def audit(self, directive):
         if self._server_uses_only_unix_sockets(directive):
+            return
+
+        if self._location_is_internal_only(directive):
+            return
+
+        if self._has_inherited_auth(directive):
             return
 
         parent = directive.parent

--- a/tests/plugins/simply/status_page_exposed/status_page_exposed_auth_basic_fp.conf
+++ b/tests/plugins/simply/status_page_exposed/status_page_exposed_auth_basic_fp.conf
@@ -1,0 +1,7 @@
+# Should NOT trigger: stub_status is protected by auth_basic on the same
+# location.
+location = /nginx_status {
+  stub_status on;
+  auth_basic "metrics";
+  auth_basic_user_file /etc/nginx/.htpasswd;
+}

--- a/tests/plugins/simply/status_page_exposed/status_page_exposed_auth_basic_off.conf
+++ b/tests/plugins/simply/status_page_exposed/status_page_exposed_auth_basic_off.conf
@@ -1,0 +1,11 @@
+# Should TRIGGER: auth_basic from the server is overridden by `off` on the
+# stub_status location, so the endpoint is unprotected.
+server {
+  auth_basic "metrics";
+  auth_basic_user_file /etc/nginx/.htpasswd;
+
+  location = /nginx_status {
+    stub_status on;
+    auth_basic off;
+  }
+}

--- a/tests/plugins/simply/status_page_exposed/status_page_exposed_auth_request_fp.conf
+++ b/tests/plugins/simply/status_page_exposed/status_page_exposed_auth_request_fp.conf
@@ -1,0 +1,20 @@
+# Should NOT trigger: stub_status is protected by an inherited auth_request
+# at the server level. Mirrors the configuration from issue #42.
+server {
+  server_name example.com;
+  auth_request /oauth2/auth;
+  error_page 401 = @redirectToAuth2ProxyLogin;
+
+  location = /oauth2/auth {
+    internal;
+    proxy_pass http://auth-backend;
+  }
+
+  location @redirectToAuth2ProxyLogin {
+    return 307 https://auth.example.com/oauth2/start;
+  }
+
+  location = /nginx_status {
+    stub_status on;
+  }
+}

--- a/tests/plugins/simply/status_page_exposed/status_page_exposed_auth_request_http_level_fp.conf
+++ b/tests/plugins/simply/status_page_exposed/status_page_exposed_auth_request_http_level_fp.conf
@@ -1,0 +1,16 @@
+# Should NOT trigger: auth_request is defined at the http level and
+# inherits all the way down to the stub_status location.
+http {
+  auth_request /oauth2/auth;
+
+  server {
+    location = /oauth2/auth {
+      internal;
+      proxy_pass http://auth-backend;
+    }
+
+    location = /nginx_status {
+      stub_status on;
+    }
+  }
+}

--- a/tests/plugins/simply/status_page_exposed/status_page_exposed_auth_request_off.conf
+++ b/tests/plugins/simply/status_page_exposed/status_page_exposed_auth_request_off.conf
@@ -1,0 +1,16 @@
+# Should TRIGGER: the inherited auth_request is explicitly turned off on
+# the stub_status location, leaving the endpoint without any access
+# control.
+server {
+  auth_request /oauth2/auth;
+
+  location = /oauth2/auth {
+    internal;
+    proxy_pass http://auth-backend;
+  }
+
+  location = /nginx_status {
+    stub_status on;
+    auth_request off;
+  }
+}

--- a/tests/plugins/simply/status_page_exposed/status_page_exposed_internal_location_fp.conf
+++ b/tests/plugins/simply/status_page_exposed/status_page_exposed_internal_location_fp.conf
@@ -1,0 +1,7 @@
+# Should NOT trigger: the location carries the `internal` directive, so
+# nginx returns 404 to direct external requests and stub_status can only
+# be reached through an internal redirect.
+location = /nginx_status {
+  internal;
+  stub_status on;
+}


### PR DESCRIPTION
The plugin only counted allow/deny when deciding whether stub_status was exposed, so a location protected by an inherited auth_request or auth_basic, or one declared `internal`, was still flagged. The audit now walks the parent scopes to resolve the effective auth_request and auth_basic (respecting `off` overrides on the location itself), and skips locations that carry `internal`.

Fixes #42.