### PR TITLE
fix(regex_redos): inspect if/server_name/rewrite/map (keep recheck server)

### DIFF
--- a/docs/en/plugins/regex_redos.md
+++ b/docs/en/plugins/regex_redos.md
@@ -11,7 +11,9 @@ This plugin checks regex usage in directives like:
 
 - `location ~ ...`
 - `if ($var ~ ...)`
+- `server_name ~ ...`
 - `rewrite ...`
+- `map` regex keys (`~...`)
 
 It warns about patterns that may cause catastrophic backtracking. This issue is also known as [ReDoS](https://en.wikipedia.org/wiki/ReDoS).
 

--- a/gixy/plugins/regex_redos.py
+++ b/gixy/plugins/regex_redos.py
@@ -6,15 +6,20 @@ except Exception:
     requests = None  # requests is optional; plugin will auto-skip without it
     _REQUESTS_AVAILABLE = False
 import gixy
+from gixy.directives.directive import MapDirective
 from gixy.plugins.plugin import Plugin
 
 
 class regex_redos(Plugin):
     r"""
-    This plugin checks all directives for regular expressions that may be
-    vulnerable to ReDoS (Regular Expression Denial of Service). ReDoS
-    vulnerabilities may be used to overwhelm nginx servers with minimal
-    resources from an attacker.
+    This plugin checks regular expressions used by nginx directives for
+    patterns that may be vulnerable to ReDoS (Regular Expression Denial of
+    Service). ReDoS vulnerabilities may be used to overwhelm nginx servers
+    with minimal resources from an attacker.
+
+    nginx runs regexes from many directives through its PCRE engine, so this
+    plugin inspects every regex-bearing source: location/if matches,
+    server_name, rewrite, and map keys.
 
     Example of a vulnerable directive:
         location ~ ^/(a|aa|aaa|aaaa)+$
@@ -42,9 +47,7 @@ class regex_redos(Plugin):
         "resources (also known as ReDoS)."
     )
     help_url = "https://gixy.io/plugins/regex_redos/"
-    directives = [
-        "location"
-    ]  # XXX: Missing server_name, rewrite, if, map, proxy_redirect
+    directives = ["location", "if", "server_name", "rewrite", "map"]
     options = {"url": ""}
     options_help = {
         "url": "URL pointing to a server running a compatible ReDoS checking server (e.g. MegaManSec/recheck-http-api.)"
@@ -56,6 +59,48 @@ class regex_redos(Plugin):
         super(regex_redos, self).__init__(config)
         self.redos_server = self.config.get("url")
 
+    @staticmethod
+    def _regexes(directive):
+        """Yield (pattern, modifier) for every regex a directive carries.
+
+        `modifier` is "i" for case-insensitive matches (~*, !~*) and "" otherwise,
+        matching the recheck request format.
+        """
+        name = directive.name
+        if name == "location":
+            if directive.modifier in ("~", "~*"):
+                yield directive.path, "i" if directive.modifier == "~*" else ""
+        elif name == "if":
+            if directive.operand in ("~", "~*", "!~", "!~*") and directive.value:
+                yield directive.value, "i" if directive.operand in ("~*", "!~*") else ""
+        elif name == "rewrite":
+            if directive.args:
+                yield directive.args[0], ""
+        elif name == "server_name":
+            args = directive.args
+            i = 0
+            while i < len(args):
+                arg = args[i]
+                if arg in ("~", "~*"):  # "~* regex" — prefix split from the pattern
+                    if i + 1 < len(args):
+                        yield args[i + 1], "i" if arg == "~*" else ""
+                    i += 2
+                    continue
+                if arg.startswith("~*"):  # "~*regex" — prefix attached
+                    yield arg[2:], "i"
+                elif arg.startswith("~"):
+                    yield arg[1:], ""
+                i += 1
+        elif name == "map":
+            for child in directive.gather_map_directives(directive.children):
+                if not isinstance(child, MapDirective) or not child.is_regex:
+                    continue
+                src = child.src_val
+                if src.startswith("~*"):
+                    yield src[2:], "i"
+                elif src.startswith("~"):
+                    yield src[1:], ""
+
     def audit(self, directive):
         # If requests is not available, skip.
         if not _REQUESTS_AVAILABLE:
@@ -64,13 +109,10 @@ class regex_redos(Plugin):
         if not self.redos_server:
             return
 
-        # Only process directives that have regex modifiers.
-        if directive.modifier not in ("~", "~*"):
-            return
+        for pattern, modifier in self._regexes(directive):
+            self._recheck(directive, pattern, modifier)
 
-        regex_pattern = directive.path
-
-        modifier = "" if directive.modifier == "~" else "i"
+    def _recheck(self, directive, regex_pattern, modifier):
         json_data = {"1": {"pattern": regex_pattern, "modifier": modifier}}
 
         # Attempt to contact the ReDoS check server.

--- a/tests/plugins/test_regex_redos.py
+++ b/tests/plugins/test_regex_redos.py
@@ -1,0 +1,40 @@
+import pytest
+
+from gixy.parser.nginx_parser import NginxParser
+from gixy.plugins.regex_redos import regex_redos
+
+
+def _regexes(config, name):
+    """Collect (pattern, modifier) the plugin would send to the recheck server
+    for every `name` directive in `config`."""
+    root = NginxParser(cwd="", allow_includes=False).parse_string(config)
+    plugin = regex_redos({})
+    out = []
+    for directive in root.find_recursive(name):
+        out.extend(plugin._regexes(directive))
+    return out
+
+
+@pytest.mark.parametrize("config,name,expected", [
+    ("location ~ ^/(a+)+$ { }", "location", [("^/(a+)+$", "")]),
+    ("location ~* ^/(a+)+$ { }", "location", [("^/(a+)+$", "i")]),
+    ('if ($http_user_agent ~ "(a+)+x") { }', "if", [("(a+)+x", "")]),
+    ('if ($http_user_agent ~* "(a+)+x") { }', "if", [("(a+)+x", "i")]),
+    ("rewrite ^/(a+)+$ /x last;", "rewrite", [("^/(a+)+$", "")]),
+    # server_name accepts the prefix either split from or attached to the pattern
+    ("server_name ~* ^(a+)+\\.ex$ www.ex.com;", "server_name", [("^(a+)+\\.ex$", "i")]),
+    ("server_name ~^(a+)+x;", "server_name", [("^(a+)+x", "")]),
+    ("map $uri $x { ~*^(a+)+$ 1; ~^/b 2; default 0; }", "map", [("^(a+)+$", "i"), ("^/b", "")]),
+])
+def test_regexes_extracted(config, name, expected):
+    assert _regexes(config, name) == expected
+
+
+@pytest.mark.parametrize("config,name", [
+    ("location /static/ { }", "location"),                 # prefix match, no regex
+    ("if ($request_method = POST) { }", "if"),             # comparison, no regex
+    ("server_name example.com *.example.com;", "server_name"),  # plain/wildcard names
+    ("map $uri $x { /a 1; default 0; }", "map"),           # literal keys, no regex
+])
+def test_no_regexes_for_non_regex_forms(config, name):
+    assert _regexes(config, name) == []


### PR DESCRIPTION
Only `location ~` regexes were sent to the ReDoS recheck service; the classic `if ($http_user_agent ~ ...)` ReDoS — plus `server_name ~`, `rewrite`, and `map` keys — was never checked.

Broadens the regexes extracted and sent to the recheck server to all five sources via a `_regexes()` helper. The external `--regex-redos-url` recheck mechanism is **kept**: real ReDoS detection (exponential *and* polynomial / overlapping-alternation classes) needs a proper engine like recheck, not a local heuristic.

The network audit remains `skip_test` (it cannot run in CI without a server); added `tests/plugins/test_regex_redos.py` covering the regex-extraction broadening (which regexes are/are not sent, per directive type). Doc updated.
