### PR TITLE
fix(origins): flag reflection of $http_origin into Access-Control-Allow-Origin

### DIFF
--- a/docs/en/plugins/origins.md
+++ b/docs/en/plugins/origins.md
@@ -5,7 +5,7 @@ description: "Flags unsafe or brittle Origin/Referer validation logic (most ofte
 
 # [origins] Weak `Referer` / `Origin` validation
 
-This check looks for common mistakes when using `$http_origin` or `$http_referer` to gate security behavior (CORS, clickjacking headers, etc.). It focuses on regex-based validation in `if` conditions and in `map`-based CORS allowlists that reflect an origin into a response header.
+This check looks for common mistakes when using `$http_origin` or `$http_referer` to gate security behavior (CORS, clickjacking headers, etc.). It covers brittle regex-based validation in `if` conditions and `map`-based CORS allowlists, as well as configurations that reflect the request `Origin` into `Access-Control-Allow-Origin` unconditionally.
 
 ## What it detects
 
@@ -29,6 +29,27 @@ It can also flag values that contain uppercase letters or unusual characters in 
 ### Common header typo
 
 `$http_referrer` is not a valid NGINX variable for the HTTP Referer header. The correct variable is `$http_referer`.
+
+### Unconditional reflection of the Origin
+
+Reflecting `$http_origin` straight back into `Access-Control-Allow-Origin` accepts *any* origin — there is no allowlist at all. The plugin flags this whether the request Origin is reflected directly, through a `set`, or via a non-regex `map` default:
+
+```nginx
+# Direct reflection — every origin is allowed
+add_header Access-Control-Allow-Origin $http_origin always;
+
+# Indirect, via set
+set $cors $http_origin;
+add_header Access-Control-Allow-Origin $cors always;
+
+# Non-regex map that defaults to reflecting the origin
+map $http_origin $cors {
+    default $http_origin;
+}
+add_header Access-Control-Allow-Origin $cors always;
+```
+
+A literal-key `map` allowlist (for example `https://trusted.example $http_origin;` with a safe `default`) is *not* flagged: only the listed origins are echoed back. Like the `map` analysis below, this detection runs only on a full configuration scan (one that includes an `http { .. }` block).
 
 ## Why this is a problem
 

--- a/gixy/plugins/origins.py
+++ b/gixy/plugins/origins.py
@@ -6,7 +6,7 @@ import tldextract
 import gixy
 from gixy.core.regexp import Regexp
 from gixy.directives.block import MapBlock
-from gixy.directives.directive import AddHeaderDirective, MapDirective
+from gixy.directives.directive import AddHeaderDirective, MapDirective, SetDirective
 from gixy.plugins.plugin import Plugin
 
 _EXTRACT = tldextract.TLDExtract(
@@ -347,6 +347,23 @@ class origins(Plugin):
         name = self.directive_type.split("_")[1]
         self._analyze_and_report(directive.value, case_sensitive, name, directive)
 
+    @staticmethod
+    def _is_origin_reflection(value):
+        """True if a (quote-stripped) value is a bare reflection of $http_origin."""
+        return value.lstrip("$").strip("{}").lower() == "http_origin"
+
+    def _report_reflection(self, directive):
+        """Flag unconditional reflection of the request Origin into Access-Control-Allow-Origin."""
+        reason = (
+            "Reflecting `$http_origin` into `Access-Control-Allow-Origin` allows any "
+            "origin to pass the CORS check. Echo only origins from a trusted allowlist."
+        )
+        self.add_issue(
+            directive=directive,
+            reason=reason,
+            severity=self.severity_insecure_origin,
+        )
+
     def post_audit(self, root):
         """Analyze map-based CORS allowlists: map $http_origin $var; add_header Access-Control-Allow-Origin $var"""
         # Find add_header directives that set Access-Control-Allow-Origin to a variable
@@ -358,7 +375,22 @@ class origins(Plugin):
             value = node.value.strip().strip("\"'")
             if not value.startswith("$"):
                 continue
+
+            # add_header Access-Control-Allow-Origin $http_origin; -> reflects every origin
+            if self._is_origin_reflection(value):
+                self._report_reflection(node)
+                continue
+
             dest_var = value.lstrip("$").lower()
+
+            # set $var $http_origin; add_header ... $var; -> indirect reflection
+            for sd in root.find_recursive("set"):
+                if not isinstance(sd, SetDirective):
+                    continue
+                if sd.variable != dest_var:
+                    continue
+                if self._is_origin_reflection(sd.value.strip().strip("\"'")):
+                    self._report_reflection([sd, node])
 
             # Find map blocks that populate this variable from $http_origin
             for mb in root.find_recursive("map"):
@@ -373,8 +405,14 @@ class origins(Plugin):
                 for md in mb.gather_map_directives(mb.children):
                     if not isinstance(md, MapDirective):
                         continue
-                    # Only consider regex map keys
+                    # A non-regex `default $http_origin;` echoes every origin back.
+                    # A literal key (`https://trusted.example $http_origin;`) is an
+                    # exact-match allowlist, so only `default` reflects unconditionally.
                     if not md.is_regex:
+                        if md.src_val == "default" and self._is_origin_reflection(
+                            (md.dest_val or "").strip().strip("\"'")
+                        ):
+                            self._report_reflection([md, node])
                         continue
                     src = md.src_val or ""
                     # Determine case sensitivity and pattern

--- a/tests/plugins/simply/origins/fixed_origin_fp.conf
+++ b/tests/plugins/simply/origins/fixed_origin_fp.conf
@@ -1,0 +1,5 @@
+http {
+    server {
+        add_header Access-Control-Allow-Origin https://fixed.example always;
+    }
+}

--- a/tests/plugins/simply/origins/reflect_add_header.conf
+++ b/tests/plugins/simply/origins/reflect_add_header.conf
@@ -1,0 +1,5 @@
+http {
+    server {
+        add_header Access-Control-Allow-Origin $http_origin always;
+    }
+}

--- a/tests/plugins/simply/origins/reflect_map_default.conf
+++ b/tests/plugins/simply/origins/reflect_map_default.conf
@@ -1,0 +1,10 @@
+http {
+    map $http_origin $allow_origin {
+        default $http_origin;
+        https://trusted.example "";
+    }
+
+    server {
+        add_header Access-Control-Allow-Origin $allow_origin always;
+    }
+}

--- a/tests/plugins/simply/origins/reflect_set.conf
+++ b/tests/plugins/simply/origins/reflect_set.conf
@@ -1,0 +1,6 @@
+http {
+    server {
+        set $allow_origin $http_origin;
+        add_header Access-Control-Allow-Origin $allow_origin always;
+    }
+}


### PR DESCRIPTION
The textbook reflected-origin CORS bug was invisible: the plugin only audited `if` conditions and regex `map` entries. A direct `add_header Access-Control-Allow-Origin $http_origin;`, an indirect `set $cors $http_origin;` then echo, and a non-regex `map ... { default $http_origin; }` all reflect every origin yet produced no finding.

Flags those three reflection forms in `post_audit`, reusing the existing dest-variable resolution. A literal-key `map` allowlist (e.g. `https://trusted.example $http_origin;` with a safe `default`) is intentionally **not** flagged — that is an exact-match allowlist, not reflection.

**Tests:** positives for direct / `set` / `map default` reflection (→ 1 each); fixed-origin fp (→ 0); all existing `origins` fixtures pass. Doc updated.
