### PR TITLE
fix(parser): break circular include cycles with an active-include guard

### DIFF
--- a/gixy/parser/nginx_parser.py
+++ b/gixy/parser/nginx_parser.py
@@ -23,6 +23,7 @@ class NginxParser(object):
         self.parser = raw_parser.RawParser()
         self._init_directives()
         self._path_stack = None
+        self._active_includes = set()
 
     def parse_file(self, path, root=None, display_path=None):
         """Parse an nginx configuration file from disk.
@@ -302,8 +303,19 @@ class NginxParser(object):
         exists = False
         for file_path in sorted(glob.iglob(path)):
             exists = True
-            # parse the include into current context
-            self.parse_file(file_path, parent)
+            # Skip includes already on the active parse stack: a self / mutual
+            # / transitive include cycle would otherwise recurse forever or
+            # duplicate the cycle's directives many times over.
+            canonical = os.path.realpath(file_path)
+            if canonical in self._active_includes:
+                LOG.warning("Skipping circular include: %s", file_path)
+                continue
+            self._active_includes.add(canonical)
+            try:
+                # parse the include into current context
+                self.parse_file(file_path, parent)
+            finally:
+                self._active_includes.discard(canonical)
 
         if not exists:
             # Align behavior with nginx: unmatched glob patterns are not warnings

--- a/tests/parser/test_nginx_parser.py
+++ b/tests/parser/test_nginx_parser.py
@@ -219,6 +219,40 @@ server {
     assert isinstance(tree_direct.children[0], HttpBlock)
     assert isinstance(tree_compat.children[0], HttpBlock)
 
+
+def test_include_self_cycle_is_broken(tmp_path):
+    """A file that includes itself must not recurse forever."""
+    (tmp_path / "self.conf").write_text("worker_processes 1;\ninclude self.conf;\n")
+    root = NginxParser(cwd=str(tmp_path), allow_includes=True).parse_file(
+        str(tmp_path / "self.conf")
+    )
+    assert isinstance(root, Root)
+    assert len(root.children) < 10
+
+
+def test_include_mutual_cycle_is_broken(tmp_path):
+    """An A <-> B mutual include cycle is broken instead of recursing."""
+    (tmp_path / "a.conf").write_text("include b.conf;\n")
+    (tmp_path / "b.conf").write_text("include a.conf;\n")
+    root = NginxParser(cwd=str(tmp_path), allow_includes=True).parse_file(
+        str(tmp_path / "a.conf")
+    )
+    assert isinstance(root, Root)
+    assert len(root.children) < 10
+
+
+def test_include_transitive_cycle_is_broken(tmp_path):
+    """An A -> B -> C -> A transitive include cycle is broken."""
+    (tmp_path / "a.conf").write_text("include b.conf;\n")
+    (tmp_path / "b.conf").write_text("include c.conf;\n")
+    (tmp_path / "c.conf").write_text("include a.conf;\n")
+    root = NginxParser(cwd=str(tmp_path), allow_includes=True).parse_file(
+        str(tmp_path / "a.conf")
+    )
+    assert isinstance(root, Root)
+    assert len(root.children) < 10
+
+
 def assert_config(config, expected):
     tree = _parse(config)
     assert isinstance(tree, Directive)


### PR DESCRIPTION
A self / mutual / transitive `include` cycle (for example a glob that matches the including file) made the parser recurse without bound — `RecursionError`, or hundreds of duplicated directives. `allow_includes` defaults on, so this is reachable in normal use.

Tracks canonical paths currently on the parse stack and skips an include already being parsed, discarding it once parsing unwinds so legitimate repeated includes still work. Adapted from `dvershinin/gixy@9b226ef`.

**Tests:** regression tests for self, A↔B, and A→B→C→A cycles (parse terminates, bounded tree).
