### PR TITLE
fix(core): tolerate unparseable regexes instead of crashing the audit

### DIFF
--- a/gixy/core/manager.py
+++ b/gixy/core/manager.py
@@ -133,15 +133,28 @@ class Manager(object):
         except Exception:
             pass
 
+    @staticmethod
+    def _provided_variables(directive):
+        """Variables a directive contributes to the scope, tolerant of regexes
+        the engine can't parse (PCRE atomic groups, possessive quantifiers).
+
+        Such a regex yields no analyzable captures rather than aborting the
+        whole audit, mirroring _register_regex_captures.
+        """
+        try:
+            return directive.variables
+        except Exception:
+            return []
+
     def _prepopulate_scope_var_values(self, tree):
         context = get_context()
         for directive in tree:
             if isinstance(directive, SCOPE_STATIC_VAR_PROVIDERS + (RootDirective, RewriteDirective)):
-                for var in directive.variables:
+                for var in self._provided_variables(directive):
                     context.add_var(var.name, var)
             elif directive.is_block and not directive.self_context:
                 if directive.provide_variables:
-                    for var in directive.variables:
+                    for var in self._provided_variables(directive):
                         context.add_var(var.name, var)
                 self._prepopulate_scope_var_values(directive.children)
 
@@ -151,7 +164,7 @@ class Manager(object):
             return
 
         context = get_context()
-        for var in directive.variables:
+        for var in self._provided_variables(directive):
             if var.name == 0 and not isinstance(directive, MapDirective):
                 # All regexps must clean indexed variables
                 context.clear_index_vars()

--- a/gixy/core/regexp.py
+++ b/gixy/core/regexp.py
@@ -1077,7 +1077,7 @@ class Regexp(object):
                 FIX_NAMED_GROUPS_RE.sub("(?P<\\1>", self.source)
             )
         except sre_parse.error as e:
-            LOG.fatal("Failed to parse regex: %s (%s)", self.source, str(e))
+            LOG.debug("Failed to parse regex: %s (%s)", self.source, str(e))
             raise e
 
         return self._parsed

--- a/tests/plugins/simply/invalid_regex/atomic_group_fp.conf
+++ b/tests/plugins/simply/invalid_regex/atomic_group_fp.conf
@@ -1,0 +1,7 @@
+server {
+    location / {
+        # Atomic group is valid PCRE but unsupported by the vendored parser;
+        # the audit must skip it gracefully, not crash. $1 is the (b+) group.
+        rewrite "^(?>a+)(b+)$" /q?g=$1 break;
+    }
+}

--- a/tests/plugins/simply/invalid_regex/possessive_quantifier_fp.conf
+++ b/tests/plugins/simply/invalid_regex/possessive_quantifier_fp.conf
@@ -1,0 +1,7 @@
+server {
+    location / {
+        # Possessive quantifier is valid PCRE but unsupported by the vendored
+        # parser; the audit must skip it gracefully, not crash. $1 is (a++).
+        rewrite "^(a++)$" /q?g=$1 break;
+    }
+}


### PR DESCRIPTION
A PCRE atomic group `(?>...)` or possessive quantifier `a++` — both valid nginx regexes — cannot be parsed by the vendored `sre_parse`. Extracting a directive's capture variables raised an unhandled `sre_parse.error` from `Manager._prepopulate_scope_var_values` / `_update_variables`, **aborting the entire scan for every plugin** (not just `invalid_regex`).

Wraps variable population in `_provided_variables()`, mirroring the existing `_register_regex_captures` guard, so such a regex yields no analyzable captures rather than killing the audit. Lowers the now-recoverable parse log from `fatal` to `debug`.

**Tests:** `simply` fixtures with an atomic group and a possessive quantifier (→ 0, scan completes, no crash); existing `invalid_regex` detection fixtures unchanged.
