### PR TITLE
fix(ssl_stapling_without_resolver): skip IP-literal ssl_stapling_responder (no DNS needed)

### DIFF
--- a/docs/en/plugins/ssl_stapling_without_resolver.md
+++ b/docs/en/plugins/ssl_stapling_without_resolver.md
@@ -79,5 +79,6 @@ http {
 
 - A `resolver` declared in the same server block is also sufficient; http-level is just the most common pattern.
 - If you pre-load the stapled response via `ssl_stapling_file`, nginx uses that file directly and does not need a resolver.
+- If `ssl_stapling_responder` is set to an IP-literal URL (for example `http://192.0.2.1/ocsp`), no DNS resolution happens, so the server is not flagged. A hostname responder — or none at all, where nginx falls back to the certificate's AIA URL — still requires a resolver.
 - A server that overrides with `ssl_stapling off;` is not flagged, even when the http block enables stapling globally.
 - Non-SSL servers (plain `listen 80;`) are skipped — stapling is irrelevant there.

--- a/gixy/plugins/ssl_stapling_without_resolver.py
+++ b/gixy/plugins/ssl_stapling_without_resolver.py
@@ -1,5 +1,26 @@
+import re
+
 import gixy
+from gixy.directives.directive import is_ipv4, is_ipv6
 from gixy.plugins.plugin import Plugin
+
+_SCHEME_RE = re.compile(r'^https?://', re.IGNORECASE)
+
+
+def _responder_host(url):
+    """Return the host portion of an ssl_stapling_responder URL, or None."""
+    url = _SCHEME_RE.sub('', url)
+    # Strip path/query/fragment
+    url = url.split('/')[0]
+    # Strip port from non-bracketed hosts
+    if url.startswith('['):
+        # IPv6 bracketed: [addr] or [addr]:port
+        bracket_end = url.find(']')
+        if bracket_end == -1:
+            return None
+        return url[:bracket_end + 1]
+    url = url.rsplit(':', 1)[0]
+    return url or None
 
 
 class ssl_stapling_without_resolver(Plugin):
@@ -31,6 +52,13 @@ class ssl_stapling_without_resolver(Plugin):
         # ssl_stapling_file pre-loads the OCSP response; no resolver needed.
         if self._in_scope(server, "ssl_stapling_file"):
             return
+
+        # ssl_stapling_responder with an IP-literal URL connects directly — no DNS needed.
+        responder = self._effective(server, "ssl_stapling_responder")
+        if responder and responder.args:
+            host = _responder_host(responder.args[0])
+            if host and (is_ipv4(host) or is_ipv6(host)):
+                return
 
         if self._in_scope(server, "resolver"):
             return

--- a/tests/plugins/simply/ssl_stapling_without_resolver/ip_literal_responder_fp.conf
+++ b/tests/plugins/simply/ssl_stapling_without_resolver/ip_literal_responder_fp.conf
@@ -1,0 +1,11 @@
+server {
+    listen 443 ssl;
+    server_name example.com;
+
+    ssl_certificate     /etc/ssl/certs/example.com.pem;
+    ssl_certificate_key /etc/ssl/private/example.com.key;
+
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    ssl_stapling_responder http://192.0.2.1/ocsp;
+}


### PR DESCRIPTION
The plugin flagged any SSL server with `ssl_stapling on` and no `resolver`, but never read `ssl_stapling_responder`. When the responder is an IP-literal URL (e.g. `http://192.0.2.1/ocsp`) no DNS resolution happens, so a resolver is unnecessary — flagging it was a false positive.

Skips the finding when an in-scope `ssl_stapling_responder` has an IP-literal host (IPv4 or bracketed IPv6), mirroring the existing `ssl_stapling_file` early-return. Hostname responders (or none, falling back to the cert AIA URL) still require a resolver and are still flagged.

**Tests:** IP-literal responder fp (→ 0); existing hostname/no-responder positive (→ 1). Doc note added.
