### PR TITLE
fix(add_header_content_type): also flag more_set_headers; compare Content-Type case-insensitively

### DIFF
--- a/docs/en/plugins/add_header_content_type.md
+++ b/docs/en/plugins/add_header_content_type.md
@@ -1,17 +1,17 @@
 ---
 title: "Duplicate Content-Type"
-description: "Flags cases where add_header is used to set Content-Type, which can create duplicate Content-Type headers. Prefer default_type, or hide the upstream header first."
+description: "Flags setting Content-Type via add_header or more_set_headers, which can create duplicate Content-Type headers. Prefer default_type, or hide the upstream header first."
 ---
 
-# [add_header_content_type] Using `add_header` to set `Content-Type`
+# [add_header_content_type] Using `add_header`/`more_set_headers` to set `Content-Type`
 
 ## What this check looks for
 
-This plugin looks for configurations that try to set the `Content-Type` response header using `add_header`.
+This plugin looks for configurations that set the `Content-Type` response header using `add_header` or `more_set_headers` (the headers-more module). The header name is matched case-insensitively.
 
 ## Why this is a problem
 
-NGINX can end up sending two `Content-Type` headers: one from the upstream, and one you added. Different clients handle duplicates differently, and caches may store an unexpected value. If you are trying to set a fallback MIME type for static content, `default_type` is the right tool.
+NGINX can end up sending two `Content-Type` headers: one from the upstream, and one you added. Different clients handle duplicates differently, and caches may store an unexpected value. If you are trying to set a fallback MIME type for static content, `default_type` is the right tool. The same recommendation applies when the header is set via `more_set_headers`: prefer `default_type` over hand-setting `Content-Type`.
 
 ## Bad configuration
 

--- a/gixy/plugins/add_header_content_type.py
+++ b/gixy/plugins/add_header_content_type.py
@@ -12,19 +12,25 @@ class add_header_content_type(Plugin):
     severity = gixy.severity.LOW
     description = "Do not set Content-Type using add_header; use default_type instead."
     help_url = "https://gixy.io/plugins/add_header_content_type/"
-    directives = ["add_header"]
+    directives = ["add_header", "more_set_headers"]
 
     def audit(self, directive):
-        if directive.header == "content-type":
-            # Check if *_hide_header Content-Type is present in the same scope
-            # This is a valid pattern to override backend Content-Type
-            if self._has_hide_header_content_type(directive):
-                return
+        ct_value = next(
+            (v for h, v in directive.headers.items() if h.lower() == "content-type"),
+            None,
+        )
+        if ct_value is None:
+            return
 
-            reason = "Use `default_type {default_type};` instead of `add_header`/`more_set_headers` to set Content-Type.".format(
-                default_type=directive.value
-            )
-            self.add_issue(directive=directive, reason=reason)
+        # Check if *_hide_header Content-Type is present in the same scope
+        # This is a valid pattern to override backend Content-Type
+        if self._has_hide_header_content_type(directive):
+            return
+
+        reason = "Use `default_type {default_type};` instead of `add_header`/`more_set_headers` to set Content-Type.".format(
+            default_type=ct_value
+        )
+        self.add_issue(directive=directive, reason=reason)
 
     def _has_hide_header_content_type(self, directive):
         """Check if *_hide_header Content-Type exists in the same scope or parent scopes"""

--- a/tests/plugins/simply/add_header_content_type/more_set_headers.conf
+++ b/tests/plugins/simply/add_header_content_type/more_set_headers.conf
@@ -1,0 +1,1 @@
+more_set_headers "Content-Type: text/html";

--- a/tests/plugins/simply/add_header_content_type/more_set_headers_other_fp.conf
+++ b/tests/plugins/simply/add_header_content_type/more_set_headers_other_fp.conf
@@ -1,0 +1,1 @@
+more_set_headers "X-Frame-Options: DENY";


### PR DESCRIPTION
The plugin only inspected `add_header` and compared the header name case-sensitively, so `more_set_headers "Content-Type: ..."` was missed (its header name is case-preserved, unlike `add_header`'s).

Adds `more_set_headers` to `directives` and matches `Content-Type` case-insensitively across both directive types, using the `headers` mapping both expose.

**Tests:** `more_set_headers` Content-Type positive (→ 1); `more_set_headers` non-CT fp (→ 0); existing `add_header` fixtures unchanged. Doc updated.
