### PR TITLE
fix(valid_referers): treat 'blocked' like 'none' (no proof of HTTP origin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Gixy-Next can detect a wide range of NGINX security and performance misconfigura
 - [[try_files_is_evil_too] `try_files` directive is evil without open_file_cache](https://gixy.io/plugins/try_files_is_evil_too/)
 - [[unanchored_regex] Unanchored regular expressions](https://gixy.io/plugins/unanchored_regex/)
 - [[unnamed_groups] Unnamed capture groups in rewrite query string](https://gixy.io/plugins/unnamed_groups/)
-- [[valid_referers] none in valid_referers](https://gixy.io/plugins/valid_referers/)
+- [[valid_referers] none/blocked in valid_referers](https://gixy.io/plugins/valid_referers/)
 - [[version_disclosure] Using insecure values for server_tokens](https://gixy.io/plugins/version_disclosure/)
 - [[worker_rlimit_nofile_vs_connections] `worker_rlimit_nofile` must be at least twice `worker_connections`](https://gixy.io/plugins/worker_rlimit_nofile_vs_connections/)
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -113,7 +113,7 @@ Gixy-Next can detect a wide range of NGINX security and performance misconfigura
 - [[try_files_is_evil_too] `try_files` directive is evil without open_file_cache](https://gixy.io/plugins/try_files_is_evil_too/)
 - [[unanchored_regex] Unanchored regular expressions](https://gixy.io/plugins/unanchored_regex/)
 - [[unnamed_groups] Unnamed capture groups in rewrite query string](https://gixy.io/plugins/unnamed_groups/)
-- [[valid_referers] none in valid_referers](https://gixy.io/plugins/valid_referers/)
+- [[valid_referers] none/blocked in valid_referers](https://gixy.io/plugins/valid_referers/)
 - [[version_disclosure] Using insecure values for server_tokens](https://gixy.io/plugins/version_disclosure/)
 - [[worker_rlimit_nofile_vs_connections] `worker_rlimit_nofile` must be at least twice `worker_connections`](https://gixy.io/plugins/worker_rlimit_nofile_vs_connections/)
 

--- a/docs/en/plugins/valid_referers.md
+++ b/docs/en/plugins/valid_referers.md
@@ -1,19 +1,19 @@
 ---
 title: "Referer Check Bypass"
-description: "Detects use of 'none' in valid_referers. Allowing missing Referer defeats the point of referer validation because attackers can omit the header."
+description: "Detects use of 'none' or 'blocked' in valid_referers. Both accept requests that cannot prove a legitimate HTTP Referer, which an attacker can trivially produce."
 ---
 
-# [valid_referers] `none` in `valid_referers`
+# [valid_referers] `none`/`blocked` in `valid_referers`
 
 ## What this check looks for
 
-This plugin warns when `valid_referers` includes the `none` keyword.
+This plugin warns when `valid_referers` includes the `none` or `blocked` keyword.
 
 ## Why this is a problem
 
-`none` means: treat requests with no `Referer` header as valid.
+`none` means: treat requests with no `Referer` header as valid. `blocked` means: treat requests whose `Referer` is present but has had its scheme stripped (for example deleted by a proxy or firewall, so the value does not start with `http://`/`https://`) as valid.
 
-The trouble is that the `Referer` header is optional. Users and browsers can drop it for perfectly normal reasons (HTTPS to HTTP redirects, referrer policy, opaque origins, `data:` URLs), and attackers can omit it deliberately. If you accept `none`, a client can bypass your referer-based control simply by not sending the header.
+The trouble is that both classes are trivially attacker-producible. The `Referer` header is optional — users and browsers can drop it for perfectly normal reasons (HTTPS to HTTP redirects, referrer policy, opaque origins, `data:` URLs), and an attacker can omit it deliberately or send a scheme-less value such as `Referer: deleted` to match `blocked`. If you accept `none` or `blocked`, a client can bypass your referer-based control simply by controlling whether and how the header is sent.
 
 ## Bad configuration
 

--- a/gixy/plugins/valid_referers.py
+++ b/gixy/plugins/valid_referers.py
@@ -8,16 +8,17 @@ class valid_referers(Plugin):
         valid_referers none server_names *.webvisor.com;
     """
 
-    summary = "none used in valid_referers."
+    summary = "none or blocked used in valid_referers."
     severity = gixy.severity.HIGH
     description = (
-        'Using "none" in valid_referers treats requests with no Referer as trusted, '
-        "effectively disabling referer-based access control and clickjacking protection."
+        'Using "none" or "blocked" in valid_referers treats requests with no or a stripped '
+        "Referer as trusted, effectively disabling referer-based access control and "
+        "clickjacking protection."
     )
     help_url = "https://gixy.io/plugins/valid_referers/"
     directives = ["valid_referers"]
 
     def audit(self, directive):
-        if any(a.lower() == "none" for a in directive.args):
-            reason = "`valid_referers` includes `none`, treating requests without a Referer as trusted."
+        if any(a.lower() in ("none", "blocked") for a in directive.args):
+            reason = "`valid_referers` includes `none` or `blocked`, treating requests without a legitimate Referer as trusted."
             self.add_issue(directive=directive, reason=reason)

--- a/tests/plugins/simply/valid_referers/blocked.conf
+++ b/tests/plugins/simply/valid_referers/blocked.conf
@@ -1,0 +1,1 @@
+valid_referers blocked server_names *.webvisor.com;


### PR DESCRIPTION
`valid_referers none` was flagged but `blocked` was not. Per `ngx_http_referer_module`, `none` = Referer absent and `blocked` = Referer present but stripped of its scheme (e.g. deleted by a proxy/firewall). Both accept requests that cannot prove a legitimate HTTP origin, and `blocked` is trivially forgeable (`Referer: deleted`) — the same trust class.

Treats `blocked` the same as `none`.

**Tests:** `blocked` positive (→ 1); existing `none` positive + fp unchanged. Docs + README/index one-liner updated.
