### PR TITLE
fix(host_spoofing): flag $http_x_forwarded_host and $cookie_* as spoofable Host sources

### DIFF
--- a/docs/en/plugins/host_spoofing.md
+++ b/docs/en/plugins/host_spoofing.md
@@ -1,13 +1,13 @@
 ---
 title: "Host Header Spoofing"
-description: "Detects unsafe use of the raw Host header ($http_host). Forwarding or trusting it can enable phishing, cache poisoning, and SSRF. Prefer $host and a strict server_name list."
+description: "Detects setting the Host from client-controlled values ($http_host, $http_x_forwarded_host, $cookie_*, $arg_*). Forwarding or trusting them can enable phishing, cache poisoning, and SSRF. Prefer $host and a strict server_name list."
 ---
 
 # [host_spoofing] Host header forgery
 
 ## What this check looks for
 
-This plugin flags configurations that forward or rely on the raw `Host` request header via `$http_host`, especially when it is passed upstream or used to build redirects/URLs.
+This plugin flags configurations that set the `Host` from a client-controlled value — `$http_host`, `$http_x_forwarded_host` (the `X-Forwarded-Host` request header), a `$cookie_*` value, or a query-string `$arg_*` — especially when it is passed upstream or used to build redirects/URLs.
 
 ## Why this is a problem
 
@@ -50,4 +50,4 @@ server {
 
 ## Additional notes
 
-In general, apply the same rule to any usage of `$http_host`: it should generally be considered untrusted.
+In general, apply the same rule to any client-controlled value used as the host — `$http_*` request headers (such as `$http_x_forwarded_host`), `$cookie_*`, and `$arg_*`: they should all be considered untrusted. Only `$host` is normalized by NGINX and tied to `server_name` selection.

--- a/gixy/plugins/host_spoofing.py
+++ b/gixy/plugins/host_spoofing.py
@@ -20,9 +20,16 @@ class host_spoofing(Plugin):
             # Not a "Host" header
             return
 
-        if value.lower() == "$http_host":
+        val = value.lower()
+        if val == "$http_host":
             reason = "Upstream Host is set from `$http_host`, which can be attacker-controlled. Prefer `$host`."
             self.add_issue(directive=directive, reason=reason)
-        elif value.lower().startswith("$arg_"):
+        elif val == "$http_x_forwarded_host":
+            reason = "Upstream Host is set from `$http_x_forwarded_host` (X-Forwarded-Host request header), which is attacker-controlled. Prefer `$host`."
+            self.add_issue(directive=directive, reason=reason)
+        elif val.startswith("$arg_"):
             reason = f"Upstream Host is set from query-string variable `{value}`, which is attacker-controlled."
+            self.add_issue(directive=directive, reason=reason)
+        elif val.startswith("$cookie_"):
+            reason = f"Upstream Host is set from cookie variable `{value}`, which is attacker-controlled."
             self.add_issue(directive=directive, reason=reason)

--- a/tests/plugins/simply/host_spoofing/cookie_host.conf
+++ b/tests/plugins/simply/host_spoofing/cookie_host.conf
@@ -1,0 +1,1 @@
+proxy_set_header Host $cookie_host;

--- a/tests/plugins/simply/host_spoofing/x_forwarded_host.conf
+++ b/tests/plugins/simply/host_spoofing/x_forwarded_host.conf
@@ -1,0 +1,1 @@
+proxy_set_header Host $http_x_forwarded_host;


### PR DESCRIPTION
`host_spoofing` only matched `$http_host` (and `$arg_*`), so other fully client-controlled values used as the proxied `Host` were missed. Adds `$http_x_forwarded_host` (the `X-Forwarded-Host` request header) and the `$cookie_*` family; `$host` (nginx-validated against `server_name`) stays safe.

**Tests:** positive fixtures for `$http_x_forwarded_host` and `$cookie_host` (→ 1); `$host` fp (→ 0). Full suite green. Doc updated.
