### PR TITLE
fix(ssrf): also flag fastcgi/uwsgi/scgi/grpc_pass with attacker-controlled targets

### DIFF
--- a/docs/en/plugins/ssrf.md
+++ b/docs/en/plugins/ssrf.md
@@ -1,13 +1,13 @@
 ---
 title: "Server Side Request Forgery"
-description: "Detects SSRF-prone proxy_pass patterns where user input controls the upstream scheme/host/path. This can allow attackers to make NGINX reach internal services."
+description: "Detects SSRF-prone proxy_pass, fastcgi_pass, uwsgi_pass, scgi_pass, and grpc_pass patterns where user input controls the upstream address. This can allow attackers to make NGINX reach internal services."
 ---
 
 # [ssrf] Server Side Request Forgery
 
 ## What this check looks for
 
-This plugin looks for `proxy_pass` usage where the upstream address is built from variables that can be influenced by the client (scheme, host, port, or path). That is the classic NGINX SSRF shape.
+This plugin looks for `proxy_pass`, `fastcgi_pass`, `uwsgi_pass`, `scgi_pass`, or `grpc_pass` usage where the upstream address is built from variables that can be influenced by the client (host, port, and — for `proxy_pass`/`grpc_pass` — the scheme or path). That is the classic NGINX SSRF shape.
 
 ## Why this is a problem
 

--- a/gixy/plugins/ssrf.py
+++ b/gixy/plugins/ssrf.py
@@ -25,7 +25,7 @@ class ssrf(Plugin):
     severity = gixy.severity.HIGH
     description = "The configuration may allow an attacker to make arbitrary requests from the vulnerable server."
     help_url = "https://gixy.io/plugins/ssrf/"
-    directives = ["proxy_pass"]
+    directives = ["proxy_pass", "fastcgi_pass", "uwsgi_pass", "scgi_pass", "grpc_pass"]
 
     def __init__(self, config):
         super(ssrf, self).__init__(config)

--- a/tests/plugins/simply/ssrf/fastcgi_pass_const_fp.conf
+++ b/tests/plugins/simply/ssrf/fastcgi_pass_const_fp.conf
@@ -1,0 +1,3 @@
+location /app/ {
+    fastcgi_pass backend;
+}

--- a/tests/plugins/simply/ssrf/fastcgi_pass_var.conf
+++ b/tests/plugins/simply/ssrf/fastcgi_pass_var.conf
@@ -1,0 +1,3 @@
+location /app/ {
+    fastcgi_pass $arg_dest;
+}

--- a/tests/plugins/simply/ssrf/grpc_pass_var.conf
+++ b/tests/plugins/simply/ssrf/grpc_pass_var.conf
@@ -1,0 +1,3 @@
+location /app/ {
+    grpc_pass $arg_dest;
+}

--- a/tests/plugins/simply/ssrf/scgi_pass_var.conf
+++ b/tests/plugins/simply/ssrf/scgi_pass_var.conf
@@ -1,0 +1,3 @@
+location /app/ {
+    scgi_pass $arg_dest;
+}

--- a/tests/plugins/simply/ssrf/uwsgi_pass_var.conf
+++ b/tests/plugins/simply/ssrf/uwsgi_pass_var.conf
@@ -1,0 +1,3 @@
+location /app/ {
+    uwsgi_pass $arg_dest;
+}


### PR DESCRIPTION
`ssrf` set `directives = ["proxy_pass"]`, so an attacker-controlled variable in `fastcgi_pass`, `uwsgi_pass`, `scgi_pass`, or `grpc_pass` was never flagged — even though they expose the same SSRF surface (the upstream `host:port`/URL is resolved from the variable at request time).

This adds those four directives to the plugin; the existing `audit()` logic handles them unchanged (a scheme-less `$arg`/`$var` target parses as the host and is flagged; a constant/named-upstream target is not).

**Tests:** `simply` fixtures — true-positive `<proto>_pass $arg_dest` → 1 issue for `fastcgi`/`uwsgi`/`scgi`/`grpc`; false-positive `fastcgi_pass <const>` → 0. Full suite green.

nginx refs: `ngx_http_fastcgi_module#fastcgi_pass`, `ngx_http_uwsgi_module#uwsgi_pass`, `ngx_http_scgi_module#scgi_pass`, `ngx_http_grpc_module#grpc_pass`.
