### PR TITLE
Release 0.4.0

### DIFF
--- a/gixy/__init__.py
+++ b/gixy/__init__.py
@@ -2,4 +2,4 @@
 
 from gixy.core import severity
 
-version = "0.3.4"
+version = "0.4.0"


### PR DESCRIPTION
Release 0.4.0.

Bumps `version` to `0.4.0`. A minor bump (not a patch) because the plugin set changed: one plugin added, one removed.

## Plugin set changes
- Add `overlapping_captures` plugin for CVE-2026-9256 (#38)
- Remove `merge_slashes_on` plugin (#48)

## Plugin accuracy (new detections / fewer false positives)
- `ssrf`: also flag `fastcgi_pass`/`uwsgi_pass`/`scgi_pass`/`grpc_pass` with attacker-controlled targets (#59)
- `host_spoofing`: flag `$http_x_forwarded_host` and `$cookie_*` as spoofable Host sources (#58)
- `valid_referers`: treat `blocked` like `none` (no proof of HTTP origin) (#57)
- `missing_worker_processes`: only count `worker_processes` in the main context (#56)
- `add_header_content_type`: also flag `more_set_headers`; compare Content-Type case-insensitively (#55)
- `ssl_stapling_without_resolver`: skip IP-literal `ssl_stapling_responder` (no DNS needed) (#54)
- `low_keepalive_requests`: ignore upstream-context directive and explicit `0` (disable) (#53)
- `origins`: flag reflection of `$http_origin` into `Access-Control-Allow-Origin` (#50)
- `regex_redos`: inspect `if`/`server_name`/`rewrite`/`map` (keep recheck server) (#49)
- `status_page_exposed`: honor `auth_request`, `auth_basic`, and `internal` (#46)
- `return_bypasses_allow_deny`: skip internally-reachable locations (#45)
- `stale_dns_cache`: handle bracketed IPv6 addresses (#44)
- `unnamed_groups`: catch if-conditions, suppress implicit-redirect & return/break FPs (#39)

## Core / parser robustness
- core: tolerate unparseable regexes instead of crashing the audit (#52)
- parser: break circular include cycles with an active-include guard (#51)

## Scanner / CI / cleanup
- scanner: handle INFORMATION severity in sort and filter chips (#37)
- Lint docs and YAML strictly in CI (#47)
- Style cleanup for CVE plugins + (*VERB) capture-walker fix (#43)

---
All 704 tests pass. Merging this and publishing the GitHub Release for `v0.4.0` triggers the PyPI Trusted Publishing workflow.
