### PR TITLE
fix(status_page_exposed): honor inherited allow/deny

### DIFF
--- a/docs/en/plugins/status_page_exposed.md
+++ b/docs/en/plugins/status_page_exposed.md
@@ -81,5 +81,6 @@ server {
 ## Additional notes
 
 - This plugin treats `allow all` as not a whitelist and does not count it as a restriction.
+- `allow`/`deny` are resolved with NGINX inheritance: rules set on an enclosing `server`/`http` scope protect a `stub_status` location that declares none of its own. (A location that sets its *own* `allow`/`deny` does not inherit the parent's, matching `ngx_http_access_module`, so in that case it must repeat them.)
 - Servers that listen only on `unix:` sockets are ignored by this check, since they are not reachable over the network.
 - Prefer keeping the endpoint unadvertised (non-obvious path) in addition to access control, but do not rely on obscurity alone.

--- a/gixy/plugins/status_page_exposed.py
+++ b/gixy/plugins/status_page_exposed.py
@@ -64,6 +64,37 @@ class status_page_exposed(Plugin):
                 return bool(getattr(parent, "is_internal", False))
         return False
 
+    @staticmethod
+    def _effective_access(directive):
+        """Resolve effective (has_allow, has_deny_all) for this scope.
+
+        allow/deny are inherited from the nearest ancestor scope that declares
+        any of them, all-or-nothing (ngx_http_access_module): once a scope sets
+        its own allow/deny, the parent's are not inherited. So we evaluate the
+        closest scope that declares either and stop there.
+        """
+        scope = directive.parent
+        while scope:
+            allow_deny = [
+                c for c in scope.children if (c.name or "").lower() in ("allow", "deny")
+            ]
+            if allow_deny:
+                has_allow = any(
+                    (c.name or "").lower() == "allow"
+                    and c.args
+                    and c.args[0].lower() != "all"  # "allow all" is not a whitelist
+                    for c in allow_deny
+                )
+                has_deny_all = any(
+                    (c.name or "").lower() == "deny"
+                    and c.args
+                    and c.args[0].lower() == "all"
+                    for c in allow_deny
+                )
+                return has_allow, has_deny_all
+            scope = scope.parent
+        return False, False
+
     def audit(self, directive):
         if self._server_uses_only_unix_sockets(directive):
             return
@@ -74,24 +105,10 @@ class status_page_exposed(Plugin):
         if self._has_inherited_auth(directive):
             return
 
-        parent = directive.parent
-        if not parent:
+        if not directive.parent:
             return
 
-        has_allow = False
-        has_deny_all = False
-
-        for child in parent.children:
-            name = (child.name or "").lower()
-            args = [a.lower() for a in (child.args or [])]
-
-            if name == "allow":
-                # "allow all" is NOT a whitelist, so don't count it
-                if args and args[0] != "all":
-                    has_allow = True
-            elif name == "deny":
-                if args and args[0] == "all":
-                    has_deny_all = True
+        has_allow, has_deny_all = self._effective_access(directive)
 
         if not has_allow or not has_deny_all:
             reasons = []

--- a/tests/plugins/simply/status_page_exposed/status_page_exposed_inherited_fp.conf
+++ b/tests/plugins/simply/status_page_exposed/status_page_exposed_inherited_fp.conf
@@ -1,0 +1,11 @@
+http {
+    server {
+        # Server-scoped allow/deny is inherited by the stub_status location,
+        # which declares none of its own — so the endpoint is protected.
+        allow 10.0.0.0/8;
+        deny all;
+        location /status {
+            stub_status;
+        }
+    }
+}


### PR DESCRIPTION
Builds on the #42 inherited-auth work (this branch stacks on #46): the allow/deny check still inspected only the directive's own scope, so a stub_status location protected by a server-scoped 'allow ...; deny all;' was flagged spuriously. Resolve allow/deny across nginx's all-or-nothing inheritance — the nearest ancestor scope that declares either wins (ngx_http_access_module).