### PR TITLE
fix(return_bypasses_allow_deny): also flag rewrite ... permanent|redi…

### DIFF
--- a/docs/en/plugins/return_bypasses_allow_deny.md
+++ b/docs/en/plugins/return_bypasses_allow_deny.md
@@ -1,17 +1,17 @@
 ---
 title: "Return Bypasses Allow/Deny"
-description: "Detects return (and rewrite ... permanent|redirect) placed alongside allow/deny in the same scope. They emit a response in the rewrite phase, before access control runs, making allow/deny misleading."
+description: "Detects return (and redirecting rewrite directives) placed alongside allow/deny in the same scope. They emit a response in the rewrite phase, before access control runs, making allow/deny misleading."
 ---
 
-# [return_bypasses_allow_deny] `return` / `rewrite ... permanent|redirect` bypass `allow`/`deny`
+# [return_bypasses_allow_deny] `return` / redirecting `rewrite` bypass `allow`/`deny`
 
 ## What this check looks for
 
-This plugin warns when `return` — or a `rewrite ... permanent` / `rewrite ... redirect` — appears in the same context as `allow`/`deny`.
+This plugin warns when `return` — or a `rewrite` that emits a redirect — appears in the same context as `allow`/`deny`. A `rewrite` emits a redirect when it carries a `permanent` (301) or `redirect` (302) flag, and also — regardless of flag — when its replacement is an absolute URL starting with `http://`, `https://`, or `$scheme`.
 
 ## Why this is a problem
 
-`return` — and a `rewrite` with a `permanent` (301) or `redirect` (302) flag — run in the rewrite phase and emit a response immediately. Access controls (`allow`/`deny`) are evaluated later, in the access phase. That means such a directive placed next to access rules can effectively ignore them, even if the config looks like it should be restricted. (A `rewrite ... last` or `rewrite ... break` keeps processing into the access phase, so it is *not* flagged.)
+`return` — and a redirecting `rewrite` — run in the rewrite phase and emit a response immediately. Access controls (`allow`/`deny`) are evaluated later, in the access phase. That means such a directive placed next to access rules can effectively ignore them, even if the config looks like it should be restricted. (A `rewrite ... last` or `rewrite ... break` whose replacement is a plain URI keeps processing toward the access phase, so it is *not* flagged. With an absolute-URL replacement, however, NGINX redirects immediately even under `last` or `break`.)
 
 In other words: the block reads like "allow X, deny everyone else", but the request never actually reaches the access phase: it simply returns unconditionally.
 
@@ -27,7 +27,7 @@ location /admin/ {
 }
 ```
 
-The response is served to everyone, including clients you intended to deny. The same happens if you replace the `return` with `rewrite ^ https://example.test/ permanent;` (or `redirect`) — the redirect is issued before the access phase.
+The response is served to everyone, including clients you intended to deny. The same happens if you replace the `return` with `rewrite ^ https://example.test/ permanent;`, or even a flagless `rewrite ^ https://example.test$request_uri;` — the redirect is issued before the access phase.
 
 ## Better configuration
 

--- a/docs/en/plugins/return_bypasses_allow_deny.md
+++ b/docs/en/plugins/return_bypasses_allow_deny.md
@@ -1,17 +1,17 @@
 ---
 title: "Return Bypasses Allow/Deny"
-description: "Detects return directives placed alongside allow/deny in the same effective scope. return short-circuits request processing and can make access controls misleading."
+description: "Detects return (and rewrite ... permanent|redirect) placed alongside allow/deny in the same scope. They emit a response in the rewrite phase, before access control runs, making allow/deny misleading."
 ---
 
-# [return_bypasses_allow_deny] `return` bypasses `allow` and `deny`
+# [return_bypasses_allow_deny] `return` / `rewrite ... permanent|redirect` bypass `allow`/`deny`
 
 ## What this check looks for
 
-This plugin warns when `return` appears in the same context as `allow`/`deny`.
+This plugin warns when `return` — or a `rewrite ... permanent` / `rewrite ... redirect` — appears in the same context as `allow`/`deny`.
 
 ## Why this is a problem
 
-`return` runs in the rewrite phase and ends request processing immediately. Access controls (`allow`/`deny`) are evaluated later. That means a `return` placed next to access rules can effectively ignore them, even if the config looks like it should be restricted.
+`return` — and a `rewrite` with a `permanent` (301) or `redirect` (302) flag — run in the rewrite phase and emit a response immediately. Access controls (`allow`/`deny`) are evaluated later, in the access phase. That means such a directive placed next to access rules can effectively ignore them, even if the config looks like it should be restricted. (A `rewrite ... last` or `rewrite ... break` keeps processing into the access phase, so it is *not* flagged.)
 
 In other words: the block reads like "allow X, deny everyone else", but the request never actually reaches the access phase: it simply returns unconditionally.
 
@@ -27,7 +27,7 @@ location /admin/ {
 }
 ```
 
-The response is served to everyone, including clients you intended to deny.
+The response is served to everyone, including clients you intended to deny. The same happens if you replace the `return` with `rewrite ^ https://example.test/ permanent;` (or `redirect`) — the redirect is issued before the access phase.
 
 ## Better configuration
 

--- a/gixy/plugins/return_bypasses_allow_deny.py
+++ b/gixy/plugins/return_bypasses_allow_deny.py
@@ -62,20 +62,30 @@ class return_bypasses_allow_deny(Plugin):
             return
         self._reported_parents.add(key)
 
-        return_directive = self._find_descendants_excluding_internal_locations(
+        # `return` and `rewrite ... permanent|redirect` both emit their response
+        # during the rewrite phase, before the access phase where allow/deny run.
+        # (`rewrite ... last|break` keep processing, so they do not bypass.)
+        bypassing = self._find_descendants_excluding_internal_locations(
             parent, "return"
         )
-        if return_directive:
-            all_allow_directives = (
-                self._find_descendants_excluding_internal_locations(parent, "allow")
+        bypassing += [
+            d
+            for d in self._find_descendants_excluding_internal_locations(
+                parent, "rewrite"
             )
-            all_deny_directives = (
-                self._find_descendants_excluding_internal_locations(parent, "deny")
+            if len(d.args) >= 3 and d.args[-1].lower() in ("permanent", "redirect")
+        ]
+        if bypassing:
+            all_allow_directives = self._find_descendants_excluding_internal_locations(
+                parent, "allow"
+            )
+            all_deny_directives = self._find_descendants_excluding_internal_locations(
+                parent, "deny"
             )
             self.add_issue(
                 directive=[directive]
-                + return_directive
+                + bypassing
                 + all_allow_directives
                 + all_deny_directives,
-                reason="`allow`/`deny` do not restrict responses produced by `return` in the same scope.",
+                reason="`allow`/`deny` do not restrict responses produced by `return` or `rewrite ... permanent|redirect` in the same scope.",
             )

--- a/gixy/plugins/return_bypasses_allow_deny.py
+++ b/gixy/plugins/return_bypasses_allow_deny.py
@@ -18,6 +18,11 @@ class return_bypasses_allow_deny(Plugin):
     help_url = "https://gixy.io/plugins/return_bypasses_allow_deny/"
     directives = ["allow", "deny"]
 
+    REDIRECT_FLAGS = ("permanent", "redirect")
+    # nginx also redirects whenever the replacement is an absolute URL,
+    # regardless of flag; its prefix check is case-sensitive (ngx_http_rewrite).
+    REDIRECT_PREFIXES = ("http://", "https://", "$scheme")
+
     def __init__(self, config):
         super(return_bypasses_allow_deny, self).__init__(config)
         self._reported_parents = set()
@@ -37,6 +42,17 @@ class return_bypasses_allow_deny(Plugin):
         if getattr(node, "path", "").startswith("@"):
             return True
         return bool(getattr(node, "is_internal", False))
+
+    @classmethod
+    def _rewrite_emits_redirect(cls, directive):
+        """True when this rewrite responds with a redirect from the rewrite
+        phase: it carries a `permanent`/`redirect` flag, or its replacement
+        is an absolute URL — the latter redirects whatever the flag, `last`
+        and `break` included."""
+        args = directive.args
+        if len(args) >= 3 and args[-1].lower() in cls.REDIRECT_FLAGS:
+            return True
+        return len(args) >= 2 and args[1].startswith(cls.REDIRECT_PREFIXES)
 
     def _find_descendants_excluding_internal_locations(self, node, name):
         result = []
@@ -62,9 +78,10 @@ class return_bypasses_allow_deny(Plugin):
             return
         self._reported_parents.add(key)
 
-        # `return` and `rewrite ... permanent|redirect` both emit their response
-        # during the rewrite phase, before the access phase where allow/deny run.
-        # (`rewrite ... last|break` keep processing, so they do not bypass.)
+        # `return` and any redirecting rewrite emit their response during the
+        # rewrite phase, before the access phase where allow/deny run.
+        # (`rewrite ... last|break` with a plain URI replacement keeps
+        # processing, so it does not bypass.)
         bypassing = self._find_descendants_excluding_internal_locations(
             parent, "return"
         )
@@ -73,7 +90,7 @@ class return_bypasses_allow_deny(Plugin):
             for d in self._find_descendants_excluding_internal_locations(
                 parent, "rewrite"
             )
-            if len(d.args) >= 3 and d.args[-1].lower() in ("permanent", "redirect")
+            if self._rewrite_emits_redirect(d)
         ]
         if bypassing:
             all_allow_directives = self._find_descendants_excluding_internal_locations(
@@ -87,5 +104,5 @@ class return_bypasses_allow_deny(Plugin):
                 + bypassing
                 + all_allow_directives
                 + all_deny_directives,
-                reason="`allow`/`deny` do not restrict responses produced by `return` or `rewrite ... permanent|redirect` in the same scope.",
+                reason="`allow`/`deny` do not restrict responses produced by `return` or by a redirecting `rewrite` in the same scope.",
             )

--- a/tests/plugins/simply/return_bypasses_allow_deny/rewrite_absolute_last.conf
+++ b/tests/plugins/simply/return_bypasses_allow_deny/rewrite_absolute_last.conf
@@ -1,0 +1,7 @@
+location /abc {
+  allow 127.0.0.2;
+  deny all;
+  # "last" does not help: an absolute-URL replacement still redirects
+  # immediately instead of restarting location matching.
+  rewrite ^ https://example.test/ last;
+}

--- a/tests/plugins/simply/return_bypasses_allow_deny/rewrite_implicit_redirect.conf
+++ b/tests/plugins/simply/return_bypasses_allow_deny/rewrite_implicit_redirect.conf
@@ -1,0 +1,7 @@
+location /abc {
+  allow 127.0.0.2;
+  deny all;
+  # No flag, but an absolute-URL replacement makes nginx return a 302
+  # from the rewrite phase, before allow/deny are consulted.
+  rewrite ^ https://example.test$request_uri;
+}

--- a/tests/plugins/simply/return_bypasses_allow_deny/rewrite_last_fp.conf
+++ b/tests/plugins/simply/return_bypasses_allow_deny/rewrite_last_fp.conf
@@ -1,0 +1,6 @@
+location /abc {
+  allow 127.0.0.2;
+  deny all;
+  # "last" keeps processing into the access phase, so it does not bypass.
+  rewrite ^/old/(.*)$ /new/$1 last;
+}

--- a/tests/plugins/simply/return_bypasses_allow_deny/rewrite_permanent.conf
+++ b/tests/plugins/simply/return_bypasses_allow_deny/rewrite_permanent.conf
@@ -1,5 +1,5 @@
 location /abc {
   allow 127.0.0.2;
   deny all;
-  rewrite ^/abc/(.*)$ /moved/$1 redirect;
+  rewrite ^ https://example.test permanent;
 }

--- a/tests/plugins/simply/return_bypasses_allow_deny/rewrite_redirect.conf
+++ b/tests/plugins/simply/return_bypasses_allow_deny/rewrite_redirect.conf
@@ -1,0 +1,5 @@
+location /abc {
+  allow 127.0.0.2;
+  deny all;
+  rewrite ^ https://example.test permanent;
+}


### PR DESCRIPTION
…rect

Builds on the #40 named-location pruning (this branch stacks on #45). A 'rewrite ... permanent|redirect' emits its redirect in the rewrite phase, before the access phase where allow/deny run — the same bypass as 'return', which was the only directive searched. 'rewrite ... last|break' keep processing and are not flagged.