### PR TITLE
fix(try_files_is_evil_too): lower severity to LOW

### DIFF
--- a/gixy/plugins/try_files_is_evil_too.py
+++ b/gixy/plugins/try_files_is_evil_too.py
@@ -11,7 +11,7 @@ class try_files_is_evil_too(Plugin):
     """
 
     summary = "try_files used without open_file_cache."
-    severity = gixy.severity.MEDIUM
+    severity = gixy.severity.LOW
     description = "Using try_files without open_file_cache adds extra stat() calls per request and can cause significant performance overhead."
     help_url = "https://gixy.io/plugins/try_files_is_evil_too/"
     directives = ["try_files"]
@@ -21,7 +21,7 @@ class try_files_is_evil_too(Plugin):
         open_file_cache = directive.find_single_directive_in_scope("open_file_cache")
         if not open_file_cache or open_file_cache.args[0].lower() == "off":
             self.add_issue(
-                severity=gixy.severity.MEDIUM,
+                severity=gixy.severity.LOW,
                 directive=[directive]
                 + ([open_file_cache] if open_file_cache is not None else []),
                 reason="`try_files` introduces extra filesystem lookups without `open_file_cache`.",

--- a/tests/plugins/simply/try_files_is_evil_too/config.json
+++ b/tests/plugins/simply/try_files_is_evil_too/config.json
@@ -1,3 +1,3 @@
 {
-  "severity": "MEDIUM"
+  "severity": "LOW"
 }


### PR DESCRIPTION
try_files without open_file_cache is a performance heuristic, not a security finding; LOW matches how comparable performance nits are rated elsewhere in the suite.