### PR TITLE
fix(allow_without_deny): don't flag the satisfy-any + auth allowlist pattern

### DIFF
--- a/docs/en/plugins/allow_without_deny.md
+++ b/docs/en/plugins/allow_without_deny.md
@@ -40,3 +40,16 @@ Now the access policy is unambiguous: allow the private range, deny everyone els
 ## Additional notes
 
 If you apply `deny all;` at a higher level (for example at `server`), and then selectively allow in a child location, that can also be valid. The important part is that the final effective policy is "allow some, deny the rest", not just "allow some".
+
+This plugin does not warn when the effective configuration is `satisfy any;` combined with an auth module (`auth_basic`, `auth_request`, or `auth_jwt`):
+
+```nginx
+location /admin/ {
+    satisfy any;
+    allow 10.0.0.0/8;
+    auth_basic "Restricted";
+    auth_basic_user_file /etc/nginx/htpasswd;
+}
+```
+
+That is the intended "IP allowlist OR authentication" pattern. Clients outside the allow list fall through to authentication whether or not `deny all;` is present, so omitting it changes nothing.

--- a/gixy/core/utils.py
+++ b/gixy/core/utils.py
@@ -1,2 +1,23 @@
 def is_indexed_name(name):
     return isinstance(name, int) or (len(name) == 1 and "1" <= name <= "9")
+
+
+def resolve_inherited_single(scope, name):
+    """Effective directive for an inheritable single-value directive.
+
+    Walks from `scope` up to the root; the nearest scope that declares
+    `name` wins, and within a scope the last declaration wins (nginx
+    inheritance semantics). Returns the directive, or None when it is
+    not set anywhere up the chain.
+    """
+    current = scope
+    while current:
+        matches = [
+            c
+            for c in current.children
+            if (c.name or "").lower() == name and c.args
+        ]
+        if matches:
+            return matches[-1]
+        current = getattr(current, "parent", None)
+    return None

--- a/gixy/plugins/allow_without_deny.py
+++ b/gixy/plugins/allow_without_deny.py
@@ -1,4 +1,5 @@
 import gixy
+from gixy.core.utils import resolve_inherited_single
 from gixy.plugins.plugin import Plugin
 
 
@@ -14,9 +15,29 @@ class allow_without_deny(Plugin):
     help_url = "https://gixy.io/plugins/allow_without_deny/"
     directives = ["allow"]
 
+    AUTH_DIRECTIVES = ("auth_basic", "auth_request", "auth_jwt")
+
     def __init__(self, config):
         super(allow_without_deny, self).__init__(config)
         self._reported_parents = set()
+
+    def _is_satisfy_any_with_auth(self, scope):
+        """True for the intended 'IP allowlist OR authentication' pattern.
+
+        Under `satisfy any`, clients outside the allow list get NGX_DECLINED
+        from the access module and fall through to the auth modules, so a
+        missing `deny all` changes nothing: they still must authenticate.
+        Without an auth module the allow list is decorative and the warning
+        stands.
+        """
+        satisfy = resolve_inherited_single(scope, "satisfy")
+        if satisfy is None or satisfy.args[0].lower() != "any":
+            return False
+        for name in self.AUTH_DIRECTIVES:
+            auth = resolve_inherited_single(scope, name)
+            if auth is not None and auth.args[0].lower() != "off":
+                return True
+        return False
 
     def audit(self, directive):
         parent = directive.parent
@@ -24,6 +45,8 @@ class allow_without_deny(Plugin):
             return
         if directive.args == ["all"]:
             # for example, "allow all" in a nested location which allows access to otherwise forbidden parent location
+            return
+        if self._is_satisfy_any_with_auth(parent):
             return
 
         key = id(parent)

--- a/tests/plugins/simply/allow_without_deny/satisfy_any_auth_basic_fp.conf
+++ b/tests/plugins/simply/allow_without_deny/satisfy_any_auth_basic_fp.conf
@@ -1,0 +1,8 @@
+server {
+    location / {
+        satisfy any;
+        allow 10.0.0.0/8;
+        auth_basic "Restricted";
+        auth_basic_user_file /etc/nginx/htpasswd;
+    }
+}

--- a/tests/plugins/simply/allow_without_deny/satisfy_any_auth_off.conf
+++ b/tests/plugins/simply/allow_without_deny/satisfy_any_auth_off.conf
@@ -1,0 +1,7 @@
+server {
+    location / {
+        satisfy any;
+        allow 10.0.0.0/8;
+        auth_basic off;
+    }
+}

--- a/tests/plugins/simply/allow_without_deny/satisfy_any_auth_request_fp.conf
+++ b/tests/plugins/simply/allow_without_deny/satisfy_any_auth_request_fp.conf
@@ -1,0 +1,7 @@
+server {
+    location / {
+        satisfy any;
+        allow 10.0.0.0/8;
+        auth_request /auth;
+    }
+}

--- a/tests/plugins/simply/allow_without_deny/satisfy_any_inherited_fp.conf
+++ b/tests/plugins/simply/allow_without_deny/satisfy_any_inherited_fp.conf
@@ -1,0 +1,8 @@
+server {
+    satisfy any;
+    auth_basic "Restricted";
+    auth_basic_user_file /etc/nginx/htpasswd;
+    location / {
+        allow 10.0.0.0/8;
+    }
+}

--- a/tests/plugins/simply/allow_without_deny/satisfy_any_no_auth.conf
+++ b/tests/plugins/simply/allow_without_deny/satisfy_any_no_auth.conf
@@ -1,0 +1,6 @@
+server {
+    location / {
+        satisfy any;
+        allow 10.0.0.0/8;
+    }
+}


### PR DESCRIPTION
'satisfy any; allow ...; auth_basic ...;' is the intended 'IP allowlist OR authentication' idiom: clients outside the allow list get NGX_DECLINED from the access module and fall through to auth either way, so a missing 'deny all' changes nothing and the HIGH warning is noise. Resolve the effective satisfy and auth directives across nginx scope inheritance (new core helper resolve_inherited_single) and suppress only when both are present; 'satisfy any' without any auth module still warns, as everyone passes in that case.