### PR TITLE
fix(invalid_regex): validate $N references in map values and across the whole scope; read $N as a single digit

### DIFF
--- a/docs/en/plugins/invalid_regex.md
+++ b/docs/en/plugins/invalid_regex.md
@@ -13,7 +13,17 @@ Common places this shows up:
 
 - `rewrite` replacement strings
 - `set` inside an `if ($var ~ regex)` block
+- regex `map` entries whose value references captures the key pattern does not define
+- `return`, `proxy_pass`, `add_header`/`more_set_headers`, `try_files` and `set` values referencing `$N` when no regex anywhere in the enclosing server (location, if, rewrite, server_name) or any map key defines that group
 - patterns that use non-capturing groups like `(?:...)` or inline modifiers like `(?i)` and then expect numbered captures
+
+Note that NGINX reads exactly one digit after `$`: `$12` means capture `$1`
+followed by a literal `2`, so only `$1` through `$9` exist.
+
+Because `$N` always refers to the most recent regex evaluation at runtime,
+the whole-scope check is deliberately conservative: it only reports a
+reference when **no** regex that could run for the request defines that
+group, which makes the reference provably empty.
 
 ## Why this is a problem
 
@@ -36,6 +46,29 @@ rewrite "^/path" /$1 redirect;
 ```
 
 The pattern has zero capture groups, so `$1` is always empty.
+
+### Case 3: map value without a capture
+
+```nginx
+map $uri $dest {
+    ~^/old/ $1;
+}
+```
+
+When a map regex is evaluated it resets the request's numbered captures, so
+`$1` in the value can only come from the entry's own pattern — which defines
+no groups here. The value is always empty.
+
+### Case 4: no capture provider anywhere in scope
+
+```nginx
+location ~ ^/static/ {
+    return 301 https://example.com/$1;
+}
+```
+
+No regex in the enclosing server defines a capture group, so `$1` is
+guaranteed empty.
 
 ## Better configuration
 

--- a/gixy/plugins/invalid_regex.py
+++ b/gixy/plugins/invalid_regex.py
@@ -2,6 +2,7 @@ import re
 
 import gixy
 from gixy.core.regexp import Regexp
+from gixy.directives.directive import MapDirective
 from gixy.plugins.plugin import Plugin
 
 
@@ -59,16 +60,21 @@ class invalid_regex(Plugin):
             self._audit_scope(directive, directive.args)
 
     @staticmethod
-    def _regex_groups(pattern, case_sensitive=True):
-        """Available capture group numbers of `pattern`, or None if it cannot
+    def _regexp_groups(regexp):
+        """Available capture group numbers of a Regexp, or None if it cannot
         be parsed (PCRE-only syntax and the like)."""
         try:
-            regexp = Regexp(pattern, case_sensitive=case_sensitive)
             available = {g for g in regexp.groups if isinstance(g, int)}
             available.discard(0)
             return available
         except Exception:
             return None
+
+    @classmethod
+    def _regex_groups(cls, pattern, case_sensitive=True):
+        """Available capture group numbers of `pattern`, or None if it cannot
+        be parsed (PCRE-only syntax and the like)."""
+        return cls._regexp_groups(Regexp(pattern, case_sensitive=case_sensitive))
 
     def _find_refs(self, strings):
         refs = set()
@@ -124,20 +130,16 @@ class invalid_regex(Plugin):
         """
         gather = getattr(directive, "gather_map_directives", None)
         if gather is None:
-            # Map *entries* share the nginx name "map"; only the block has
-            # children to gather.
+            # Not the map block but an entry: entries carry their *key* as
+            # `.name`, so one whose key is literally "map" (geo entries use
+            # the same class) can be dispatched here too.
             return
 
         for child in gather(directive.children):
-            if not getattr(child, "is_regex", False):
-                continue
-
-            src = child.src_val
-            if src.startswith("~*"):
-                pattern, case_sensitive = src[2:], False
-            elif src.startswith("~"):
-                pattern, case_sensitive = src[1:], True
-            else:
+            # MapDirective parses regex keys into `.regex`; static keys
+            # (and `default`) carry None and run no regex of their own.
+            regex = getattr(child, "regex", None)
+            if regex is None:
                 continue
 
             value = child.dest_val
@@ -148,7 +150,7 @@ class invalid_regex(Plugin):
             if not referenced_groups:
                 continue
 
-            available_groups = self._regex_groups(pattern, case_sensitive)
+            available_groups = self._regexp_groups(regex)
             if available_groups is None:
                 continue
 
@@ -159,7 +161,7 @@ class invalid_regex(Plugin):
                     directive=child,
                     reason=(
                         f"The map value references capture group(s) {invalid_list}, "
-                        f'but the pattern "{pattern}" does not define them; '
+                        f'but the pattern "{regex.source}" does not define them; '
                         f"the reference is always empty."
                     ),
                 )
@@ -310,9 +312,9 @@ class invalid_regex(Plugin):
                 break
             groups |= provided
 
-        if groups is not None and root is not None and base is not root:
-            for pattern, case_sensitive in self._map_patterns(root):
-                provided = self._regex_groups(pattern, case_sensitive)
+        if groups is not None and root is not None:
+            for regexp in self._map_patterns(root):
+                provided = self._regexp_groups(regexp)
                 if provided is None:
                     groups = None
                     break
@@ -326,6 +328,12 @@ class invalid_regex(Plugin):
         `block`: regex locations, regex if conditions, rewrites and regex
         server_names."""
         for child in getattr(block, "children", []):
+            if isinstance(child, MapDirective):
+                # map/geo entries carry arbitrary key strings as `.name`,
+                # which may collide with the directive names matched below;
+                # regex map keys are collected by _map_patterns instead.
+                continue
+
             name = (getattr(child, "name", None) or "").lower()
             args = getattr(child, "args", None) or []
 
@@ -346,17 +354,13 @@ class invalid_regex(Plugin):
                 yield from self._provider_patterns(child)
 
     def _map_patterns(self, root):
-        """Yield (pattern, case_sensitive) for every regex map key in the config."""
+        """Yield the parsed Regexp of every regex map key in the config."""
         for child in getattr(root, "children", []):
             gather = getattr(child, "gather_map_directives", None)
             if gather is not None:
                 for entry in gather(child.children):
-                    if not getattr(entry, "is_regex", False):
-                        continue
-                    src = entry.src_val
-                    if src.startswith("~*"):
-                        yield src[2:], False
-                    elif src.startswith("~"):
-                        yield src[1:], True
+                    regex = getattr(entry, "regex", None)
+                    if regex is not None:
+                        yield regex
             if getattr(child, "is_block", False):
                 yield from self._map_patterns(child)

--- a/gixy/plugins/invalid_regex.py
+++ b/gixy/plugins/invalid_regex.py
@@ -14,22 +14,68 @@ class invalid_regex(Plugin):
         rewrite "(?i)/" $1 break;  # (?i) is a non-capturing flag, no groups exist
         rewrite "^/path" $1 redirect;  # No capturing groups in pattern
         if ($uri ~ "^/test") { set $x $1; }  # No capturing groups in pattern
+        map $uri $dest { ~^/old/ $1; }  # No capturing groups in pattern
+        location ~ ^/static/ { return 301 /$1; }  # No groups anywhere in scope
     """
 
     summary = "Using a nonexistent regex capture group."
     severity = gixy.severity.MEDIUM
     description = "Referencing a capture group (like $1, $2) that does not exist in the regex pattern will result in an empty value."
     help_url = "https://gixy.io/plugins/invalid_regex/"
-    directives = ["rewrite", "set"]
+    directives = [
+        "rewrite",
+        "set",
+        "return",
+        "proxy_pass",
+        "add_header",
+        "more_set_headers",
+        "try_files",
+        "map",
+    ]
 
-    # Pattern to find $1, $2, etc. references in strings
-    CAPTURE_GROUP_REF = re.compile(r"\$([1-9]\d*)")
+    # Pattern to find $1..$9 references in strings. nginx reads exactly one
+    # digit after `$` (ngx_http_script_compile), so `$12` is capture $1
+    # followed by a literal "2" and `$10`-style references don't exist.
+    CAPTURE_GROUP_REF = re.compile(r"\$([1-9])")
+
+    REGEX_OPERATORS = ("~", "~*", "!~", "!~*")
+
+    def __init__(self, config):
+        super(invalid_regex, self).__init__(config)
+        self._scope_groups_cache = {}
 
     def audit(self, directive):
         if directive.name == "rewrite":
             self._audit_rewrite(directive)
+        elif directive.name == "map":
+            self._audit_map(directive)
         elif directive.name == "set":
-            self._audit_set(directive)
+            if not self._audit_set(directive):
+                # Not in an `if` with a regex condition: fall back to the
+                # conservative whole-scope check.
+                if len(directive.args) >= 2:
+                    self._audit_scope(directive, directive.args[1:2])
+        else:
+            self._audit_scope(directive, directive.args)
+
+    @staticmethod
+    def _regex_groups(pattern, case_sensitive=True):
+        """Available capture group numbers of `pattern`, or None if it cannot
+        be parsed (PCRE-only syntax and the like)."""
+        try:
+            regexp = Regexp(pattern, case_sensitive=case_sensitive)
+            available = {g for g in regexp.groups if isinstance(g, int)}
+            available.discard(0)
+            return available
+        except Exception:
+            return None
+
+    def _find_refs(self, strings):
+        refs = set()
+        for value in strings:
+            for match in self.CAPTURE_GROUP_REF.finditer(value):
+                refs.add(int(match.group(1)))
+        return refs
 
     def _audit_rewrite(self, directive):
         """Audit rewrite directives for invalid group references."""
@@ -40,20 +86,13 @@ class invalid_regex(Plugin):
         replacement = directive.args[1]
 
         # Find all referenced capture groups in the replacement string
-        referenced_groups = set()
-        for match in self.CAPTURE_GROUP_REF.finditer(replacement):
-            referenced_groups.add(int(match.group(1)))
-
+        referenced_groups = self._find_refs([replacement])
         if not referenced_groups:
             return
 
         # Parse the regex to determine available groups
-        try:
-            regexp = Regexp(pattern, case_sensitive=True)
-            available_groups = set(regexp.groups.keys())
-            # Remove group 0 (the full match) from available groups
-            available_groups.discard(0)
-        except Exception:
+        available_groups = self._regex_groups(pattern, case_sensitive=True)
+        if available_groups is None:
             # If we can't parse the regex, skip this check
             return
 
@@ -76,20 +115,68 @@ class invalid_regex(Plugin):
 
             self.add_issue(directive=directive, reason=reason)
 
-    def _audit_set(self, directive):
-        """Audit set directives that may reference regex groups from parent if blocks."""
-        if len(directive.args) < 2:
+    def _audit_map(self, directive):
+        """Audit regex entries of map blocks.
+
+        When a map regex matches (or fails to match), it resets the request's
+        numbered captures, so `$N` in an entry's value can only refer to that
+        entry's own pattern.
+        """
+        gather = getattr(directive, "gather_map_directives", None)
+        if gather is None:
+            # Map *entries* share the nginx name "map"; only the block has
+            # children to gather.
             return
+
+        for child in gather(directive.children):
+            if not getattr(child, "is_regex", False):
+                continue
+
+            src = child.src_val
+            if src.startswith("~*"):
+                pattern, case_sensitive = src[2:], False
+            elif src.startswith("~"):
+                pattern, case_sensitive = src[1:], True
+            else:
+                continue
+
+            value = child.dest_val
+            if not value:
+                continue
+
+            referenced_groups = self._find_refs([value])
+            if not referenced_groups:
+                continue
+
+            available_groups = self._regex_groups(pattern, case_sensitive)
+            if available_groups is None:
+                continue
+
+            invalid_groups = referenced_groups - available_groups
+            if invalid_groups:
+                invalid_list = ", ".join(f"${g}" for g in sorted(invalid_groups))
+                self.add_issue(
+                    directive=child,
+                    reason=(
+                        f"The map value references capture group(s) {invalid_list}, "
+                        f'but the pattern "{pattern}" does not define them; '
+                        f"the reference is always empty."
+                    ),
+                )
+
+    def _audit_set(self, directive):
+        """Audit set directives inside if blocks with regex conditions.
+
+        Returns True when the directive was handled here (it sits inside an
+        `if` with a regex operator), False otherwise.
+        """
+        if len(directive.args) < 2:
+            return False
 
         value = directive.args[1]
 
         # Find all referenced capture groups
-        referenced_groups = set()
-        for match in self.CAPTURE_GROUP_REF.finditer(value):
-            referenced_groups.add(int(match.group(1)))
-
-        if not referenced_groups:
-            return
+        referenced_groups = self._find_refs([value])
 
         # Check if this set is inside an if block with a regex
         parent = directive.parent
@@ -103,25 +190,27 @@ class invalid_regex(Plugin):
 
         if not if_directive:
             # Not in an if block, can't determine regex context
-            return
+            return False
 
         # Check if the if condition has a regex operator
         if not hasattr(if_directive, "args") or len(if_directive.args) < 3:
-            return
+            return False
 
         operator = if_directive.args[1]
-        if operator not in ["~", "~*", "!~", "!~*"]:
-            return
+        if operator not in self.REGEX_OPERATORS:
+            return False
+
+        if not referenced_groups:
+            return True
 
         pattern = if_directive.args[2]
 
         # Parse the regex to determine available groups
-        try:
-            regexp = Regexp(pattern, case_sensitive=(operator in ["~", "!~"]))
-            available_groups = set(regexp.groups.keys())
-            available_groups.discard(0)
-        except Exception:
-            return
+        available_groups = self._regex_groups(
+            pattern, case_sensitive=(operator in ["~", "!~"])
+        )
+        if available_groups is None:
+            return True
 
         # For negative match operators the block only executes when the regex did NOT
         # match, so any capture groups from this pattern are never populated here.
@@ -157,3 +246,117 @@ class invalid_regex(Plugin):
                 )
 
             self.add_issue(directive=directive, reason=reason)
+
+        return True
+
+    def _audit_scope(self, directive, strings):
+        """Conservative whole-scope check for any other directive.
+
+        nginx's `$N` always refers to the most recent regex evaluation, which
+        cannot be pinned down statically. But when *no* regex that could
+        possibly run for the request defines group N, the reference is
+        guaranteed empty — only that case is reported.
+        """
+        referenced_groups = self._find_refs(strings)
+        if not referenced_groups:
+            return
+
+        available_groups = self._collect_scope_groups(directive)
+        if available_groups is None:
+            # An unparseable provider regex could define anything: stay quiet.
+            return
+
+        invalid_groups = referenced_groups - available_groups
+        if invalid_groups:
+            invalid_list = ", ".join(f"${g}" for g in sorted(invalid_groups))
+            self.add_issue(
+                directive=directive,
+                reason=(
+                    f"The directive references capture group(s) {invalid_list}, "
+                    f"but no regex in the enclosing configuration (location, if, "
+                    f"rewrite, server_name, or map) defines them; the reference "
+                    f"is always empty."
+                ),
+            )
+
+    def _collect_scope_groups(self, directive):
+        """Union of capture groups defined by every regex that could populate
+        `$N` for a request handled in this directive's scope: the enclosing
+        server's location/if/rewrite/server_name patterns plus any map regex
+        keys in the whole config (maps evaluate lazily). Returns None when a
+        provider pattern cannot be parsed."""
+        server = None
+        root = None
+        node = directive.parent
+        while node:
+            if getattr(node, "name", None) == "server" and server is None:
+                server = node
+            root = node
+            node = getattr(node, "parent", None)
+
+        base = server or root
+        if base is None:
+            return set()
+
+        cache_key = id(base)
+        if cache_key in self._scope_groups_cache:
+            return self._scope_groups_cache[cache_key]
+
+        groups = set()
+        for pattern, case_sensitive in self._provider_patterns(base):
+            provided = self._regex_groups(pattern, case_sensitive)
+            if provided is None:
+                groups = None
+                break
+            groups |= provided
+
+        if groups is not None and root is not None and base is not root:
+            for pattern, case_sensitive in self._map_patterns(root):
+                provided = self._regex_groups(pattern, case_sensitive)
+                if provided is None:
+                    groups = None
+                    break
+                groups |= provided
+
+        self._scope_groups_cache[cache_key] = groups
+        return groups
+
+    def _provider_patterns(self, block):
+        """Yield (pattern, case_sensitive) for every capture provider under
+        `block`: regex locations, regex if conditions, rewrites and regex
+        server_names."""
+        for child in getattr(block, "children", []):
+            name = (getattr(child, "name", None) or "").lower()
+            args = getattr(child, "args", None) or []
+
+            if name == "location" and len(args) == 2 and args[0] in ("~", "~*"):
+                yield args[1], args[0] == "~"
+            elif name == "if" and len(args) == 3 and args[1] in self.REGEX_OPERATORS:
+                yield args[2], args[1] in ("~", "!~")
+            elif name == "rewrite" and args:
+                yield args[0], True
+            elif name == "server_name":
+                for arg in args:
+                    if arg.startswith("~*"):
+                        yield arg[2:], False
+                    elif arg.startswith("~"):
+                        yield arg[1:], True
+
+            if getattr(child, "is_block", False):
+                yield from self._provider_patterns(child)
+
+    def _map_patterns(self, root):
+        """Yield (pattern, case_sensitive) for every regex map key in the config."""
+        for child in getattr(root, "children", []):
+            gather = getattr(child, "gather_map_directives", None)
+            if gather is not None:
+                for entry in gather(child.children):
+                    if not getattr(entry, "is_regex", False):
+                        continue
+                    src = entry.src_val
+                    if src.startswith("~*"):
+                        yield src[2:], False
+                    elif src.startswith("~"):
+                        yield src[1:], True
+            if getattr(child, "is_block", False):
+                yield from self._map_patterns(child)

--- a/tests/plugins/simply/invalid_regex/http_map_provider_fp.conf
+++ b/tests/plugins/simply/invalid_regex/http_map_provider_fp.conf
@@ -1,0 +1,13 @@
+http {
+    map $uri $dest {
+        ~^/x/(.+)$ /go/$1;
+    }
+    # Evaluated at send time: $1 may hold the map key's capture, even for a
+    # directive that sits outside any server.
+    add_header X-Tail $1;
+    server {
+        location / {
+            return 301 $dest;
+        }
+    }
+}

--- a/tests/plugins/simply/invalid_regex/if_provider_fp.conf
+++ b/tests/plugins/simply/invalid_regex/if_provider_fp.conf
@@ -1,0 +1,8 @@
+server {
+    location / {
+        if ($request_uri ~ "^/(.+)$") {
+            set $tail $1;
+        }
+        return 301 /x/$1;
+    }
+}

--- a/tests/plugins/simply/invalid_regex/map_named_group_fp.conf
+++ b/tests/plugins/simply/invalid_regex/map_named_group_fp.conf
@@ -1,0 +1,8 @@
+map $uri $dest {
+    "~^/old/(?<rest>.*)$" /new/$1;
+}
+server {
+    location / {
+        return 301 $dest;
+    }
+}

--- a/tests/plugins/simply/invalid_regex/map_no_group.conf
+++ b/tests/plugins/simply/invalid_regex/map_no_group.conf
@@ -1,0 +1,8 @@
+map $uri $dest {
+    ~^/old/ $1;
+}
+server {
+    location / {
+        return 301 $dest;
+    }
+}

--- a/tests/plugins/simply/invalid_regex/multidigit_fp.conf
+++ b/tests/plugins/simply/invalid_regex/multidigit_fp.conf
@@ -1,0 +1,6 @@
+server {
+    location / {
+        # nginx reads a single digit: $12 is capture $1 followed by literal "2"
+        rewrite "^/(.*)$" /x/$12 break;
+    }
+}

--- a/tests/plugins/simply/invalid_regex/proxy_pass_no_provider.conf
+++ b/tests/plugins/simply/invalid_regex/proxy_pass_no_provider.conf
@@ -1,0 +1,5 @@
+server {
+    location /api/ {
+        proxy_pass http://backend/$1;
+    }
+}

--- a/tests/plugins/simply/invalid_regex/return_no_provider.conf
+++ b/tests/plugins/simply/invalid_regex/return_no_provider.conf
@@ -1,0 +1,5 @@
+server {
+    location ~ ^/static/ {
+        return 301 https://example.com/$1;
+    }
+}

--- a/tests/plugins/simply/invalid_regex/rewrite_provider_fp.conf
+++ b/tests/plugins/simply/invalid_regex/rewrite_provider_fp.conf
@@ -1,0 +1,6 @@
+server {
+    location / {
+        rewrite "^/(old)/" /new/ break;
+        return 301 /x/$1;
+    }
+}

--- a/tests/plugins/simply/invalid_regex/server_name_provider_fp.conf
+++ b/tests/plugins/simply/invalid_regex/server_name_provider_fp.conf
@@ -1,0 +1,6 @@
+server {
+    server_name ~^(www)\.example\.com$;
+    location / {
+        return 301 /x/$1;
+    }
+}

--- a/tests/plugins/simply/proxy_pass_normalized/missing_variable_fp.conf
+++ b/tests/plugins/simply/proxy_pass_normalized/missing_variable_fp.conf
@@ -1,7 +1,8 @@
 location /b {
-  rewrite ^ $request_uri; # Sets the $1/$uri variable to the raw path
-  proxy_pass http://127.0.0.1:8000/$1; # $1 used, resulting in path being passed as the raw path from the original request.
+  rewrite ^ $request_uri;              # URI := raw (unnormalized) request path
+  rewrite ^/b/(.*)$ /$1 break;         # strip the prefix, stop rewriting
+  proxy_pass http://127.0.0.1:8000/$1; # $1 carries the raw remainder
 }
 
-# Request received by nginx: /%2F
-# Request received by backend: /%2F # Possibly also receives //%2F)
+# Request received by nginx: /b/%2F
+# Request received by backend: /%2F

--- a/tests/plugins/simply/proxy_pass_normalized/missing_variable_nopath_fp.conf
+++ b/tests/plugins/simply/proxy_pass_normalized/missing_variable_nopath_fp.conf
@@ -1,8 +1,8 @@
 location /b {
-  rewrite ^ $request_uri; # Sets the $1/$uri variable to the raw path
-  proxy_pass http://127.0.0.1:8000$1; # $1 used in host, resulting in path being passed as the raw path from the original request.
+  rewrite ^ $request_uri;             # URI := raw (unnormalized) request path
+  rewrite ^/b(/.*)$ $1 break;         # keep the leading slash, stop rewriting
+  proxy_pass http://127.0.0.1:8000$1; # $1 used without a URI part of its own
 }
 
-# Request received by nginx: /%2F
-# Request received by backend: /%2F # Possibly also receives //%2F)
-# This is actually no different than proxy_pass_path_fp.conf since $1 is not a path.
+# Request received by nginx: /b/%2F
+# Request received by backend: /%2F


### PR DESCRIPTION
Previously only rewrite replacements and set-inside-if were checked, so a $1 against a captureless regex went undetected in map values, server_name/location regex contexts, return, proxy_pass, add_header, more_set_headers and try_files. Two new checks:

- map entries (exact): a map regex evaluation resets the request's numbered captures — verified against nginx at runtime — so $N in a regex entry's value can only come from that entry's own pattern.
- whole-scope (conservative): for other value-carrying directives, flag $N only when no regex that could run for the request — the enclosing server's location/if/rewrite/server_name patterns, plus any map regex key — defines group N, making the reference provably empty. Any unparseable provider pattern silences the check.

Also fix the reference tokenizer: nginx reads exactly one digit after $ (ngx_http_script_compile), so $12 is capture $1 followed by a literal 2; the old [1-9]\d* tokenizer reported $12 as a nonexistent group 12 (false positive).