### PR TITLE
tests: pin probe-verified behaviors of the recently merged plugin fixes

### DIFF
--- a/tests/plugins/simply/allow_without_deny/auth_without_satisfy.conf
+++ b/tests/plugins/simply/allow_without_deny/auth_without_satisfy.conf
@@ -1,0 +1,9 @@
+server {
+    location / {
+        # Without "satisfy any" both the allow list and the auth module
+        # must pass, so the missing "deny all" is still a real problem.
+        allow 10.0.0.0/8;
+        auth_basic "Restricted";
+        auth_basic_user_file /etc/nginx/htpasswd;
+    }
+}

--- a/tests/plugins/simply/allow_without_deny/satisfy_all_explicit.conf
+++ b/tests/plugins/simply/allow_without_deny/satisfy_all_explicit.conf
@@ -1,0 +1,10 @@
+server {
+    location / {
+        # With "satisfy all" the allow list cannot grant access on its
+        # own, so a missing "deny all" still leaves the warning valid.
+        satisfy all;
+        allow 10.0.0.0/8;
+        auth_basic "Restricted";
+        auth_basic_user_file /etc/nginx/htpasswd;
+    }
+}

--- a/tests/plugins/simply/allow_without_deny/satisfy_any_auth_jwt_fp.conf
+++ b/tests/plugins/simply/allow_without_deny/satisfy_any_auth_jwt_fp.conf
@@ -1,0 +1,8 @@
+server {
+    location / {
+        satisfy any;
+        allow 10.0.0.0/8;
+        auth_jwt "closed site";
+        auth_jwt_key_file conf/keys.jwk;
+    }
+}

--- a/tests/plugins/simply/allow_without_deny/satisfy_any_sibling_scope.conf
+++ b/tests/plugins/simply/allow_without_deny/satisfy_any_sibling_scope.conf
@@ -1,0 +1,13 @@
+server {
+    location /admin/ {
+        satisfy any;
+        allow 10.0.0.0/8;
+        auth_basic "Restricted";
+        auth_basic_user_file /etc/nginx/htpasswd;
+    }
+    # The sibling's satisfy/auth must not leak here: this allow has no
+    # deny and no auth fallback of its own.
+    location /open/ {
+        allow 10.0.0.0/8;
+    }
+}

--- a/tests/plugins/simply/invalid_regex/add_header_no_provider.conf
+++ b/tests/plugins/simply/invalid_regex/add_header_no_provider.conf
@@ -1,0 +1,5 @@
+server {
+    location /static/ {
+        add_header X-Debug "capture=$1";
+    }
+}

--- a/tests/plugins/simply/invalid_regex/map_key_named_map.conf
+++ b/tests/plugins/simply/invalid_regex/map_key_named_map.conf
@@ -1,0 +1,12 @@
+map $uri $dest {
+    # A static key spelled "map" collides with the block's own directive
+    # name; the plugin must skip it without crashing and still validate
+    # the regex entry below.
+    map     special;
+    ~^/old/ $1;
+}
+server {
+    location / {
+        return 301 $dest;
+    }
+}

--- a/tests/plugins/simply/invalid_regex/map_static_value_fp.conf
+++ b/tests/plugins/simply/invalid_regex/map_static_value_fp.conf
@@ -1,0 +1,12 @@
+map $uri $dest {
+    # Static and default entries run no regex of their own, so captures
+    # from whichever regex matched earlier flow into their values; they
+    # must not be validated against the key.
+    default /fallback/$1;
+    /exact  /static/$1;
+}
+server {
+    location ~ ^/(.+)$ {
+        return 301 $dest;
+    }
+}

--- a/tests/plugins/simply/invalid_regex/multidigit_no_group.conf
+++ b/tests/plugins/simply/invalid_regex/multidigit_no_group.conf
@@ -1,0 +1,7 @@
+server {
+    location / {
+        # $12 reads as capture $1 plus a literal "2"; with no groups in
+        # the pattern the missing group reported must be $1, not $12.
+        rewrite "^/path" /x/$12 break;
+    }
+}

--- a/tests/plugins/simply/invalid_regex/set_no_provider.conf
+++ b/tests/plugins/simply/invalid_regex/set_no_provider.conf
@@ -1,0 +1,6 @@
+server {
+    location /api/ {
+        set $tail $1;
+        return 301 /v2/$tail;
+    }
+}

--- a/tests/plugins/simply/invalid_regex/set_scope_provider_fp.conf
+++ b/tests/plugins/simply/invalid_regex/set_scope_provider_fp.conf
@@ -1,0 +1,6 @@
+server {
+    location ~ ^/api/(.+)$ {
+        set $tail $1;
+        return 301 /v2/$tail;
+    }
+}

--- a/tests/plugins/simply/invalid_regex/sibling_location_provider_fp.conf
+++ b/tests/plugins/simply/invalid_regex/sibling_location_provider_fp.conf
@@ -1,0 +1,11 @@
+server {
+    location ~ ^/old/(.+)$ {
+        return 301 /new/$1;
+    }
+    # Internal redirects make "which regex ran" path-dependent, so the
+    # whole-scope union spans every location of the server: the sibling's
+    # capture keeps this reference plausible.
+    location /api/ {
+        return 301 /v2/$1;
+    }
+}

--- a/tests/plugins/simply/invalid_regex/try_files_no_provider.conf
+++ b/tests/plugins/simply/invalid_regex/try_files_no_provider.conf
@@ -1,0 +1,5 @@
+server {
+    location /files/ {
+        try_files $uri /fallback/$1 =404;
+    }
+}

--- a/tests/plugins/simply/invalid_regex/unparseable_provider_fp.conf
+++ b/tests/plugins/simply/invalid_regex/unparseable_provider_fp.conf
@@ -1,0 +1,11 @@
+server {
+    location / {
+        # The atomic group is valid PCRE that the vendored parser cannot
+        # read; an unparseable provider could define anything, so the
+        # whole-scope check stays quiet.
+        if ($uri ~ "^/(?>atomic)x") {
+            return 403;
+        }
+        return 301 /x/$1;
+    }
+}

--- a/tests/plugins/simply/return_bypasses_allow_deny/rewrite_break_fp.conf
+++ b/tests/plugins/simply/return_bypasses_allow_deny/rewrite_break_fp.conf
@@ -1,0 +1,7 @@
+location /abc {
+  allow 127.0.0.2;
+  deny all;
+  # "break" with a plain URI replacement keeps processing into the
+  # access phase, so it does not bypass.
+  rewrite ^/abc/(.*)$ /static/$1 break;
+}

--- a/tests/plugins/simply/return_bypasses_allow_deny/rewrite_in_named_location_fp.conf
+++ b/tests/plugins/simply/return_bypasses_allow_deny/rewrite_in_named_location_fp.conf
@@ -1,0 +1,12 @@
+# The named-location pruning that applies to `return` must equally apply
+# to redirecting rewrites: @fallback is only reachable via internal
+# redirect, after the originating location's access phase already ran.
+server {
+  allow 127.0.0.1;
+  deny all;
+  error_page 401 = @fallback;
+
+  location @fallback {
+    rewrite ^ https://example.test/ permanent;
+  }
+}

--- a/tests/plugins/simply/return_bypasses_allow_deny/rewrite_no_flag_relative_fp.conf
+++ b/tests/plugins/simply/return_bypasses_allow_deny/rewrite_no_flag_relative_fp.conf
@@ -1,0 +1,8 @@
+location /abc {
+  allow 127.0.0.2;
+  deny all;
+  # A flagless rewrite with a plain URI replacement emits no response in
+  # the rewrite phase (it restarts location matching), so it is not a
+  # bypass and must stay unflagged.
+  rewrite ^/abc/(.*)$ /new/$1;
+}

--- a/tests/plugins/simply/return_bypasses_allow_deny/rewrite_scheme_redirect.conf
+++ b/tests/plugins/simply/return_bypasses_allow_deny/rewrite_scheme_redirect.conf
@@ -1,0 +1,7 @@
+location /abc {
+  allow 127.0.0.2;
+  deny all;
+  # A $scheme-prefixed replacement is an absolute URL: nginx returns the
+  # redirect from the rewrite phase even with "break".
+  rewrite ^ $scheme://example.test$request_uri break;
+}

--- a/tests/plugins/simply/return_bypasses_allow_deny/rewrite_uppercase_url_fp.conf
+++ b/tests/plugins/simply/return_bypasses_allow_deny/rewrite_uppercase_url_fp.conf
@@ -1,0 +1,9 @@
+location /abc {
+  allow 127.0.0.2;
+  deny all;
+  # nginx's absolute-URL detection is case-sensitive: an uppercase
+  # "HTTP://" replacement is NOT detected as a redirect; it is treated
+  # as a plain URI rewrite, so no response is emitted from the rewrite
+  # phase.
+  rewrite ^ HTTP://example.test/;
+}

--- a/tests/plugins/simply/status_page_exposed/status_page_exposed_http_level_fp.conf
+++ b/tests/plugins/simply/status_page_exposed/status_page_exposed_http_level_fp.conf
@@ -1,0 +1,11 @@
+http {
+    # Access rules declared at http level are inherited all the way down
+    # to the stub_status location, which declares none of its own.
+    allow 10.0.0.0/8;
+    deny all;
+    server {
+        location /status {
+            stub_status;
+        }
+    }
+}

--- a/tests/plugins/simply/status_page_exposed/status_page_exposed_override_partial.conf
+++ b/tests/plugins/simply/status_page_exposed/status_page_exposed_override_partial.conf
@@ -1,0 +1,13 @@
+http {
+    server {
+        allow 10.0.0.0/8;
+        deny all;
+        location /status {
+            stub_status;
+            # The location's own access rules replace the inherited ones
+            # wholesale (ngx_http_access_module), and without its own
+            # "deny all" everyone outside 127.0.0.1 is allowed by default.
+            allow 127.0.0.1;
+        }
+    }
+}

--- a/tests/plugins/simply/status_page_exposed/status_page_exposed_server_context.conf
+++ b/tests/plugins/simply/status_page_exposed/status_page_exposed_server_context.conf
@@ -1,0 +1,5 @@
+server {
+    # stub_status is valid directly in server context and must still be
+    # audited there.
+    stub_status;
+}

--- a/tests/plugins/simply/unanchored_regex/escaped_backslash_z.conf
+++ b/tests/plugins/simply/unanchored_regex/escaped_backslash_z.conf
@@ -1,0 +1,3 @@
+location ~ "/v1/.+\\z" {
+    fastcgi_pass /path/to/some.sock;
+}

--- a/tests/plugins/simply/unanchored_regex/icase_unanchored.conf
+++ b/tests/plugins/simply/unanchored_regex/icase_unanchored.conf
@@ -1,0 +1,3 @@
+location ~* \.php {
+    fastcgi_pass /path/to/some.sock;
+}

--- a/tests/plugins/simply/unanchored_regex/lookahead_anchor_fp.conf
+++ b/tests/plugins/simply/unanchored_regex/lookahead_anchor_fp.conf
@@ -1,0 +1,3 @@
+location ~ "(?=^/foo)/foo/bar" {
+    fastcgi_pass /path/to/some.sock;
+}

--- a/tests/plugins/simply/unanchored_regex/prefix_location_fp.conf
+++ b/tests/plugins/simply/unanchored_regex/prefix_location_fp.conf
@@ -1,0 +1,3 @@
+location /v1/ {
+    fastcgi_pass /path/to/some.sock;
+}

--- a/tests/plugins/simply/unanchored_regex/repeat_anchor_fp.conf
+++ b/tests/plugins/simply/unanchored_regex/repeat_anchor_fp.conf
@@ -1,0 +1,3 @@
+location ~ "(^/foo)+bar" {
+    fastcgi_pass /path/to/some.sock;
+}

--- a/tests/plugins/simply/unanchored_regex/repeat_optional_anchor.conf
+++ b/tests/plugins/simply/unanchored_regex/repeat_optional_anchor.conf
@@ -1,0 +1,3 @@
+location ~ "(^/foo)*bar" {
+    fastcgi_pass /path/to/some.sock;
+}

--- a/tests/plugins/simply/unanchored_regex/string_anchors_fp.conf
+++ b/tests/plugins/simply/unanchored_regex/string_anchors_fp.conf
@@ -1,0 +1,3 @@
+location ~ "\A/v1|/v2\Z" {
+    fastcgi_pass /path/to/some.sock;
+}

--- a/tests/plugins/simply/unanchored_regex/unparseable_regex_fp.conf
+++ b/tests/plugins/simply/unanchored_regex/unparseable_regex_fp.conf
@@ -1,0 +1,3 @@
+location ~ "(?>atomic)/v1" {
+    fastcgi_pass /path/to/some.sock;
+}


### PR DESCRIPTION
Each of these was verified by hand (CLI probes, and runtime checks against nginx 1.27 in docker) while reviewing #62-#67 but had no test pinning it:

- status_page_exposed: http-level allow/deny inheritance; a location whose own partial rules replace the inherited ones (all-or-nothing merge) is flagged again.
- return_bypasses_allow_deny: 'rewrite ... break' with a URI replacement reaches the access phase (not flagged); a $scheme:// replacement redirects even under 'break' (flagged); the absolute-URL prefix check is case-sensitive like nginx's, so 'HTTP://' does not count.
- unanchored_regex: \A/\Z string anchors; a lookahead carrying the anchor; min>=1 repeats anchor while min=0 repeats do not; an escaped backslash before 'z' is not a \z anchor.
- allow_without_deny: auth_jwt participates in the satisfy-any suppression; an explicit 'satisfy all' still warns.
- invalid_regex: the set-outside-if fallback path (flag without a provider, stay quiet with one); an unparseable provider regex silences the whole-scope check; add_header and try_files are audited; a static map key spelled 'map' is skipped without crashing while the sibling regex entry is still validated.