### PR TITLE
fix(origins): narrow bare excepts and stop fall-through after invalid-URL reclassification

### DIFF
--- a/gixy/formatters/base.py
+++ b/gixy/formatters/base.py
@@ -114,7 +114,7 @@ class BaseFormatter(object):
             printable = type(leap) not in self.skip_parents
             # Special hack for includes
             # TODO(buglloc): fix me
-            have_parentheses = type(leap) != block.IncludeBlock
+            have_parentheses = leap.__class__ is not block.IncludeBlock
 
             if printable:
                 if leap.is_block and result:

--- a/gixy/plugins/origins.py
+++ b/gixy/plugins/origins.py
@@ -121,7 +121,9 @@ class origins(Plugin):
                 return
 
             return parsed_url
-        except:
+        except (TypeError, ValueError, IndexError):
+            # IndexError: url[0] above on an empty candidate (e.g. generated
+            # from a fully-optional pattern like '^(http://mysite.com)?$').
             self.invalid_set.add(url)
 
     def _analyze_and_report(self, pattern, case_sensitive, name, directive):
@@ -283,6 +285,7 @@ class origins(Plugin):
                     if not parsed_url.scheme or not parsed_url.hostname:
                         self.invalid_set.add(url)
                         self.insecure_set.remove(url)
+                        continue
                     if name == "origin":
                         if (
                             len(
@@ -295,7 +298,7 @@ class origins(Plugin):
                         ):
                             self.invalid_set.add(url)
                             self.insecure_set.remove(url)
-                except:
+                except (TypeError, ValueError):
                     continue
             if self.insecure_set:
                 invalids = ", ".join(self.insecure_set).replace("`", "a")


### PR DESCRIPTION
Replace the two bare `except:` clauses with explicit exception tuples. parse_url() needs IndexError in the tuple: a fully-optional pattern like '^(http://mysite.com)?$' generates an empty candidate, and url[0] on an empty string raises IndexError (previously swallowed by the bare except).

Also add the missing `continue` after a scheme-less/host-less URL is moved from insecure_set to invalid_set; without it, execution falls through to the origin path-check which can call insecure_set.remove() a second time and raise KeyError (previously masked by the bare except).

While here, replace the type() != comparison in formatters/base.py with an identity check (flake8 E721).

Adapted from dvershinin/gixy@e3a2881 (which narrows to TypeError/ ValueError only and appears to have the latent IndexError crash).