### PR TITLE
feat: add SARIF output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,13 @@ $ gixy -f json
 [{"config":"\nserver {\n\n\tlocation ~ /v1/((?<action>[^.]*)\\.json)?$ {\n\t\tadd_header X-Action $action;\n\t}\n}","description":"Using variables that can contain \"\\n\" or \"\\r\" may lead to http injection.","file":"/etc/nginx/nginx.conf","line":4,"path":"/etc/nginx/nginx.conf","plugin":"http_splitting","reason":"At least variable \"$action\" can contain \"\\n\"","reference":"https://gixy.io/plugins/http_splitting/","severity":"HIGH","summary":"Possible HTTP-Splitting vulnerability."}]
 ```
 
+You can also use `-f sarif` to get a [SARIF 2.1.0](https://sarifweb.azurewebsites.net/) log, e.g. for uploading to GitHub code scanning:
+
+```shell-session
+# Write a SARIF report to a file, e.g. for `github/codeql-action/upload-sarif`
+gixy -f sarif -o gixy-results.sarif
+```
+
 More flags for usage can be found by passing `--help` to `gixy`. You can also find more information in the [Usage Guide](https://gixy.io/usage/).
 
 ## Configuration and plugin options

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -80,6 +80,7 @@ Choose the output format:
 format = console   # default, colored output
 # format = text    # plain text (no ANSI)
 # format = json    # machine-readable JSON
+# format = sarif   # SARIF 2.1.0, e.g. for GitHub code scanning
 ```
 
 ### output

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -185,6 +185,13 @@ $ gixy -f json
 [{"config":"\nserver {\n\n\tlocation ~ /v1/((?<action>[^.]*)\\.json)?$ {\n\t\tadd_header X-Action $action;\n\t}\n}","description":"Using variables that can contain \"\\n\" or \"\\r\" may lead to http injection.","file":"/etc/nginx/nginx.conf","line":4,"path":"/etc/nginx/nginx.conf","plugin":"http_splitting","reason":"At least variable \"$action\" can contain \"\\n\"","reference":"https://gixy.io/plugins/http_splitting/","severity":"HIGH","summary":"Possible HTTP-Splitting vulnerability."}]
 ```
 
+You can also use `-f sarif` to get a [SARIF 2.1.0](https://sarifweb.azurewebsites.net/) log, e.g. for uploading to GitHub code scanning:
+
+```shell-session
+# Write a SARIF report to a file, e.g. for `github/codeql-action/upload-sarif`
+gixy -f sarif -o gixy-results.sarif
+```
+
 More flags for usage can be found by passing `--help` to `gixy`. You can also find more information in the [Usage Guide](https://gixy.io/usage/).
 
 ## Configuration and plugin options

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -129,6 +129,29 @@ gixy -f text
 
 # JSON: Reproducible JSON, best for CI and post-processing.
 gixy -f json
+
+# SARIF 2.1.0: for tooling that consumes SARIF, e.g. GitHub code scanning.
+gixy -f sarif
+```
+
+### SARIF output (GitHub code scanning)
+
+The `sarif` format emits a [SARIF 2.1.0](https://sarifweb.azurewebsites.net/) log, which is a standard format understood by many code-scanning tools, including GitHub's. Write it to a file and upload it with [`github/codeql-action/upload-sarif`](https://github.com/github/codeql-action/tree/main/upload-sarif) to see findings as annotations on your PRs and in the Security tab:
+
+```shell-session
+# Write a SARIF report to a file
+gixy -f sarif -o gixy-results.sarif
+```
+
+```yaml
+# Example GitHub Actions step
+- name: Scan NGINX config with Gixy-Next
+  run: gixy /etc/nginx/nginx.conf -f sarif -o gixy-results.sarif
+
+- name: Upload SARIF results
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: gixy-results.sarif
 ```
 
 ## Write reports to a file

--- a/gixy/formatters/sarif.py
+++ b/gixy/formatters/sarif.py
@@ -13,6 +13,14 @@ _SEVERITY_TO_LEVEL = {
     gixy.severity.INFORMATION: "note",
 }
 
+# GitHub code scanning buckets "security-severity" scores as:
+# >= 9.0 critical, 7.0-8.9 high, 4.0-6.9 medium, < 4.0 low.
+_SEVERITY_TO_SCORE = {
+    gixy.severity.HIGH: "8.0",
+    gixy.severity.MEDIUM: "5.0",
+    gixy.severity.LOW: "2.0",
+}
+
 
 def _to_uri(path):
     """Turn a filesystem path into a SARIF URI, repo-relative when possible."""
@@ -49,6 +57,9 @@ class SarifFormatter(BaseFormatter):
                     }
                     if issue["help_url"]:
                         rule["helpUri"] = issue["help_url"]
+                    score = _SEVERITY_TO_SCORE.get(issue["severity"])
+                    if score:
+                        rule["properties"] = {"security-severity": score}
                     rules[rule_id] = rule
 
                 result = {

--- a/gixy/formatters/sarif.py
+++ b/gixy/formatters/sarif.py
@@ -21,6 +21,43 @@ _SEVERITY_TO_SCORE = {
     gixy.severity.LOW: "2.0",
 }
 
+_SEVERITY_RANK = {severity: rank for rank, severity in enumerate(gixy.severity.ALL)}
+
+
+def _upsert_rule(rules, rule_severities, issue):
+    """Register the issue's rule, keeping its metadata at the highest severity.
+
+    Plugins can emit issues at different severities under one rule id, and
+    consumers like GitHub bucket every alert of a rule by its rule-level
+    "security-severity".
+    """
+    rule_id = issue["plugin"]
+    severity = issue["severity"]
+
+    if rule_id not in rules:
+        rule = {
+            "id": rule_id,
+            "shortDescription": {"text": issue["summary"] or rule_id},
+            "fullDescription": {
+                "text": issue["description"] or issue["summary"] or rule_id
+            },
+        }
+        if issue["help_url"]:
+            rule["helpUri"] = issue["help_url"]
+        rules[rule_id] = rule
+
+    if _SEVERITY_RANK.get(severity, 0) > _SEVERITY_RANK.get(
+        rule_severities.get(rule_id), -1
+    ):
+        rule = rules[rule_id]
+        rule["defaultConfiguration"] = {
+            "level": _SEVERITY_TO_LEVEL.get(severity, "warning")
+        }
+        score = _SEVERITY_TO_SCORE.get(severity)
+        if score:
+            rule["properties"] = {"security-severity": score}
+        rule_severities[rule_id] = severity
+
 
 def _to_uri(path):
     """Turn a filesystem path into a SARIF URI, repo-relative when possible."""
@@ -39,28 +76,14 @@ class SarifFormatter(BaseFormatter):
 
     def format_reports(self, reports, stats):
         rules = {}
+        rule_severities = {}
         results = []
 
         for path, issues in reports.items():
             for issue in issues:
                 rule_id = issue["plugin"]
                 level = _SEVERITY_TO_LEVEL.get(issue["severity"], "warning")
-
-                if rule_id not in rules:
-                    rule = {
-                        "id": rule_id,
-                        "shortDescription": {"text": issue["summary"] or rule_id},
-                        "fullDescription": {
-                            "text": issue["description"] or issue["summary"] or rule_id
-                        },
-                        "defaultConfiguration": {"level": level},
-                    }
-                    if issue["help_url"]:
-                        rule["helpUri"] = issue["help_url"]
-                    score = _SEVERITY_TO_SCORE.get(issue["severity"])
-                    if score:
-                        rule["properties"] = {"security-severity": score}
-                    rules[rule_id] = rule
+                _upsert_rule(rules, rule_severities, issue)
 
                 result = {
                     "ruleId": rule_id,

--- a/gixy/formatters/sarif.py
+++ b/gixy/formatters/sarif.py
@@ -65,9 +65,10 @@ class SarifFormatter(BaseFormatter):
                 location = issue.get("location")
                 if location and location.get("file"):
                     uri = location["file"]
-                elif path and path != "-":
-                    uri = path
                 else:
+                    uri = path
+                if uri in ("-", "<stdin>"):
+                    # stdin has no artifact to point at, and "<stdin>" is not a valid URI
                     uri = None
 
                 if uri:

--- a/gixy/formatters/sarif.py
+++ b/gixy/formatters/sarif.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import json
 import os
+from pathlib import Path
 
 import gixy
 from gixy.formatters.base import BaseFormatter
@@ -59,16 +60,23 @@ def _upsert_rule(rules, rule_severities, issue):
         rule_severities[rule_id] = severity
 
 
-def _to_uri(path):
-    """Turn a filesystem path into a SARIF URI, repo-relative when possible."""
+def _artifact_location(path, base):
+    """Build a SARIF artifactLocation for a filesystem path.
+
+    Paths under the base directory become URIs relative to the SRCROOT
+    base declared in the run's originalUriBaseIds; anything else gets an
+    absolute file:// URI, so consumers never resolve a path against the
+    wrong root.
+    """
+    abspath = os.path.abspath(path)
     try:
-        rel = os.path.relpath(path)
+        rel = os.path.relpath(abspath, base)
     except ValueError:
-        # Windows: path on a different drive than the working directory
-        rel = path
-    if not rel.startswith(os.pardir):
-        path = rel
-    return path.replace(os.sep, "/")
+        # Windows: path on a different drive than the base directory
+        rel = None
+    if rel is not None and rel != os.pardir and not rel.startswith(os.pardir + os.sep):
+        return {"uri": rel.replace(os.sep, "/"), "uriBaseId": "SRCROOT"}
+    return {"uri": Path(abspath).as_uri()}
 
 
 class SarifFormatter(BaseFormatter):
@@ -78,6 +86,9 @@ class SarifFormatter(BaseFormatter):
         rules = {}
         rule_severities = {}
         results = []
+        # The scan-time working directory anchors relative URIs; in CI this
+        # is the checked-out workspace, which is what GitHub resolves against.
+        base = os.getcwd()
 
         for path, issues in reports.items():
             for issue in issues:
@@ -107,7 +118,7 @@ class SarifFormatter(BaseFormatter):
 
                 if uri:
                     physical_location = {
-                        "artifactLocation": {"uri": _to_uri(uri)},
+                        "artifactLocation": _artifact_location(uri, base),
                     }
                     if location and location.get("line"):
                         physical_location["region"] = {"startLine": location["line"]}
@@ -127,6 +138,10 @@ class SarifFormatter(BaseFormatter):
                             "version": gixy.version,
                             "rules": sorted(rules.values(), key=lambda r: r["id"]),
                         }
+                    },
+                    # Base URIs must end with a slash per the SARIF spec
+                    "originalUriBaseIds": {
+                        "SRCROOT": {"uri": Path(base).as_uri() + "/"}
                     },
                     "results": results,
                 }

--- a/gixy/formatters/sarif.py
+++ b/gixy/formatters/sarif.py
@@ -1,0 +1,106 @@
+from __future__ import absolute_import
+
+import json
+import os
+
+import gixy
+from gixy.formatters.base import BaseFormatter
+
+_SEVERITY_TO_LEVEL = {
+    gixy.severity.HIGH: "error",
+    gixy.severity.MEDIUM: "warning",
+    gixy.severity.LOW: "note",
+    gixy.severity.INFORMATION: "note",
+}
+
+
+def _to_uri(path):
+    """Turn a filesystem path into a SARIF-friendly (preferably repo-relative) URI."""
+    try:
+        rel = os.path.relpath(path)
+    except ValueError:
+        rel = path
+
+    if not rel.startswith(os.pardir):
+        path = rel
+
+    return path.replace(os.sep, "/")
+
+
+class SarifFormatter(BaseFormatter):
+    """Formats reports as a SARIF 2.1.0 log, e.g. for GitHub code scanning."""
+
+    def format_reports(self, reports, stats):
+        rules = {}
+        results = []
+
+        for path, issues in reports.items():
+            for issue in issues:
+                rule_id = issue["plugin"]
+                level = _SEVERITY_TO_LEVEL.get(issue["severity"], "warning")
+
+                if rule_id not in rules:
+                    rules[rule_id] = {
+                        "id": rule_id,
+                        "shortDescription": {"text": issue["summary"] or rule_id},
+                        "fullDescription": {
+                            "text": issue["description"]
+                            or issue["summary"]
+                            or rule_id
+                        },
+                        "helpUri": issue["help_url"] or "",
+                        "defaultConfiguration": {"level": level},
+                    }
+
+                location = issue.get("location")
+                if location and location.get("file"):
+                    uri = location["file"]
+                elif path and path not in ("<stdin>", "-"):
+                    uri = path
+                else:
+                    uri = None
+
+                result = {
+                    "ruleId": rule_id,
+                    "level": level,
+                    "message": {"text": issue["summary"] or rule_id},
+                }
+
+                properties = {}
+                if issue.get("reason"):
+                    properties["reason"] = issue["reason"]
+                if issue.get("config"):
+                    properties["config"] = issue["config"].strip("\n")
+                if properties:
+                    result["properties"] = properties
+
+                if uri:
+                    physical_location = {
+                        "artifactLocation": {"uri": _to_uri(uri)},
+                    }
+                    line = location.get("line") if location else None
+                    if line:
+                        physical_location["region"] = {"startLine": line}
+                    result["locations"] = [{"physicalLocation": physical_location}]
+
+                results.append(result)
+
+        sarif_log = {
+            "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {
+                        "driver": {
+                            "name": "Gixy-Next",
+                            "informationUri": "https://github.com/dvershinin/gixy",
+                            "version": gixy.version,
+                            "rules": sorted(rules.values(), key=lambda r: r["id"]),
+                        }
+                    },
+                    "results": results,
+                }
+            ],
+        }
+
+        return json.dumps(sarif_log, indent=2, sort_keys=False)

--- a/gixy/formatters/sarif.py
+++ b/gixy/formatters/sarif.py
@@ -15,15 +15,14 @@ _SEVERITY_TO_LEVEL = {
 
 
 def _to_uri(path):
-    """Turn a filesystem path into a SARIF-friendly (preferably repo-relative) URI."""
+    """Turn a filesystem path into a SARIF URI, repo-relative when possible."""
     try:
         rel = os.path.relpath(path)
     except ValueError:
+        # Windows: path on a different drive than the working directory
         rel = path
-
     if not rel.startswith(os.pardir):
         path = rel
-
     return path.replace(os.sep, "/")
 
 
@@ -40,60 +39,56 @@ class SarifFormatter(BaseFormatter):
                 level = _SEVERITY_TO_LEVEL.get(issue["severity"], "warning")
 
                 if rule_id not in rules:
-                    rules[rule_id] = {
+                    rule = {
                         "id": rule_id,
                         "shortDescription": {"text": issue["summary"] or rule_id},
                         "fullDescription": {
-                            "text": issue["description"]
-                            or issue["summary"]
-                            or rule_id
+                            "text": issue["description"] or issue["summary"] or rule_id
                         },
-                        "helpUri": issue["help_url"] or "",
                         "defaultConfiguration": {"level": level},
                     }
-
-                location = issue.get("location")
-                if location and location.get("file"):
-                    uri = location["file"]
-                elif path and path not in ("<stdin>", "-"):
-                    uri = path
-                else:
-                    uri = None
+                    if issue["help_url"]:
+                        rule["helpUri"] = issue["help_url"]
+                    rules[rule_id] = rule
 
                 result = {
                     "ruleId": rule_id,
                     "level": level,
-                    "message": {"text": issue["summary"] or rule_id},
+                    "message": {
+                        "text": issue["reason"] or issue["summary"] or rule_id
+                    },
                 }
 
-                properties = {}
-                if issue.get("reason"):
-                    properties["reason"] = issue["reason"]
-                if issue.get("config"):
-                    properties["config"] = issue["config"].strip("\n")
-                if properties:
-                    result["properties"] = properties
+                if issue["config"]:
+                    result["properties"] = {"config": issue["config"].strip("\n")}
+
+                location = issue.get("location")
+                if location and location.get("file"):
+                    uri = location["file"]
+                elif path and path != "-":
+                    uri = path
+                else:
+                    uri = None
 
                 if uri:
                     physical_location = {
                         "artifactLocation": {"uri": _to_uri(uri)},
                     }
-                    line = location.get("line") if location else None
-                    if line:
-                        physical_location["region"] = {"startLine": line}
+                    if location and location.get("line"):
+                        physical_location["region"] = {"startLine": location["line"]}
                     result["locations"] = [{"physicalLocation": physical_location}]
 
                 results.append(result)
 
         sarif_log = {
-            "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+            "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
             "version": "2.1.0",
             "runs": [
                 {
                     "tool": {
                         "driver": {
                             "name": "Gixy-Next",
-                            "informationUri": "https://github.com/dvershinin/gixy",
+                            "informationUri": "https://gixy.io/",
                             "version": gixy.version,
                             "rules": sorted(rules.values(), key=lambda r: r["id"]),
                         }
@@ -103,4 +98,4 @@ class SarifFormatter(BaseFormatter):
             ],
         }
 
-        return json.dumps(sarif_log, indent=2, sort_keys=False)
+        return json.dumps(sarif_log, indent=2)

--- a/tests/formatters/test_sarif.py
+++ b/tests/formatters/test_sarif.py
@@ -67,6 +67,7 @@ def test_sarif_result_fields():
     )
     assert rule["defaultConfiguration"]["level"] == "error"
     assert rule["helpUri"] == "https://gixy.io/plugins/http_splitting/"
+    assert rule["properties"]["security-severity"] == "8.0"
 
 
 def test_stdin_results_have_no_location():

--- a/tests/formatters/test_sarif.py
+++ b/tests/formatters/test_sarif.py
@@ -1,6 +1,7 @@
 import io
 import json
 
+import gixy
 from gixy.core.context import purge_context
 from gixy.core.manager import Manager
 from gixy.formatters.sarif import SarifFormatter, _to_uri
@@ -68,6 +69,42 @@ def test_sarif_result_fields():
     assert rule["defaultConfiguration"]["level"] == "error"
     assert rule["helpUri"] == "https://gixy.io/plugins/http_splitting/"
     assert rule["properties"]["security-severity"] == "8.0"
+
+
+def test_rule_metadata_uses_highest_issue_severity():
+    # Plugins like alias_traversal emit per-issue severities; the rule's
+    # defaultConfiguration/security-severity must reflect the highest one,
+    # not whichever issue happened to be walked first
+    def issue(severity):
+        return {
+            "plugin": "alias_traversal",
+            "summary": "Path traversal via misconfigured alias.",
+            "severity": severity,
+            "description": "",
+            "help_url": "https://gixy.io/plugins/alias_traversal/",
+            "reason": "",
+            "config": "",
+            "location": None,
+        }
+
+    formatter = SarifFormatter()
+    log = json.loads(
+        formatter.format_reports(
+            {
+                "/etc/nginx/nginx.conf": [
+                    issue(gixy.severity.MEDIUM),
+                    issue(gixy.severity.HIGH),
+                ]
+            },
+            {},
+        )
+    )
+
+    rule = log["runs"][0]["tool"]["driver"]["rules"][0]
+    assert rule["defaultConfiguration"]["level"] == "error"
+    assert rule["properties"]["security-severity"] == "8.0"
+    # Result levels still follow each issue's own severity
+    assert [r["level"] for r in log["runs"][0]["results"]] == ["warning", "error"]
 
 
 def test_stdin_results_have_no_location():

--- a/tests/formatters/test_sarif.py
+++ b/tests/formatters/test_sarif.py
@@ -4,7 +4,7 @@ import json
 import gixy
 from gixy.core.context import purge_context
 from gixy.core.manager import Manager
-from gixy.formatters.sarif import SarifFormatter, _to_uri
+from gixy.formatters.sarif import SarifFormatter, _artifact_location
 
 SPLITTING_CONFIG = r"""
 http {
@@ -44,6 +44,10 @@ def test_sarif_log_structure():
     assert rule_ids == sorted(rule_ids)
     assert "http_splitting" in rule_ids
 
+    srcroot = log["runs"][0]["originalUriBaseIds"]["SRCROOT"]["uri"]
+    assert srcroot.startswith("file://")
+    assert srcroot.endswith("/")
+
 
 def test_sarif_result_fields():
     log = _format("/etc/nginx/nginx.conf", SPLITTING_CONFIG)
@@ -59,7 +63,8 @@ def test_sarif_result_fields():
     assert "add_header X-Action $action" in result["properties"]["config"]
 
     location = result["locations"][0]["physicalLocation"]
-    assert location["artifactLocation"]["uri"] == "/etc/nginx/nginx.conf"
+    # /etc/nginx is outside the working directory, so the URI stays absolute
+    assert location["artifactLocation"]["uri"] == "file:///etc/nginx/nginx.conf"
     assert location["region"]["startLine"] == 5
 
     rule = next(
@@ -130,7 +135,19 @@ def test_no_issues_produces_empty_run():
     assert log["runs"][0]["tool"]["driver"]["rules"] == []
 
 
-def test_to_uri_relativizes_paths_under_cwd(tmp_path, monkeypatch):
-    monkeypatch.chdir(str(tmp_path))
-    assert _to_uri(str(tmp_path / "conf.d" / "site.conf")) == "conf.d/site.conf"
-    assert _to_uri("/somewhere/else/nginx.conf") == "/somewhere/else/nginx.conf"
+def test_artifact_location_anchors_paths_under_base_to_srcroot(tmp_path):
+    base = str(tmp_path)
+
+    assert _artifact_location(str(tmp_path / "conf.d" / "site.conf"), base) == {
+        "uri": "conf.d/site.conf",
+        "uriBaseId": "SRCROOT",
+    }
+    # A file whose name merely starts with ".." is still under the base
+    assert _artifact_location(str(tmp_path / "..weird.conf"), base) == {
+        "uri": "..weird.conf",
+        "uriBaseId": "SRCROOT",
+    }
+    # Paths outside the base get an absolute file:// URI
+    assert _artifact_location("/somewhere/else/nginx.conf", base) == {
+        "uri": "file:///somewhere/else/nginx.conf"
+    }

--- a/tests/formatters/test_sarif.py
+++ b/tests/formatters/test_sarif.py
@@ -1,0 +1,82 @@
+import io
+import json
+
+from gixy.core.context import purge_context
+from gixy.core.manager import Manager
+from gixy.formatters.sarif import SarifFormatter, _to_uri
+
+SPLITTING_CONFIG = r"""
+http {
+server {
+    location ~ /v1/((?<action>[^.]*)\.json)?$ {
+        add_header X-Action $action;
+    }
+}
+}
+"""
+
+
+def teardown_function():
+    purge_context()
+
+
+def _format(path, config):
+    manager = Manager()
+    manager.audit(path, io.StringIO(config), is_stdin=True)
+    formatter = SarifFormatter()
+    formatter.feed(path, manager)
+    return json.loads(formatter.flush())
+
+
+def test_sarif_log_structure():
+    log = _format("/etc/nginx/nginx.conf", SPLITTING_CONFIG)
+
+    assert log["version"] == "2.1.0"
+    assert "sarif-schema-2.1.0" in log["$schema"]
+    assert len(log["runs"]) == 1
+
+    driver = log["runs"][0]["tool"]["driver"]
+    assert driver["name"] == "Gixy-Next"
+    assert driver["informationUri"] == "https://gixy.io/"
+
+    rule_ids = [rule["id"] for rule in driver["rules"]]
+    assert rule_ids == sorted(rule_ids)
+    assert "http_splitting" in rule_ids
+
+
+def test_sarif_result_fields():
+    log = _format("/etc/nginx/nginx.conf", SPLITTING_CONFIG)
+
+    results = [
+        r for r in log["runs"][0]["results"] if r["ruleId"] == "http_splitting"
+    ]
+    assert len(results) == 1
+    result = results[0]
+
+    assert result["level"] == "error"
+    assert "$action" in result["message"]["text"]
+    assert "add_header X-Action $action" in result["properties"]["config"]
+
+    location = result["locations"][0]["physicalLocation"]
+    assert location["artifactLocation"]["uri"] == "/etc/nginx/nginx.conf"
+    assert location["region"]["startLine"] == 5
+
+    rule = next(
+        r for r in log["runs"][0]["tool"]["driver"]["rules"]
+        if r["id"] == "http_splitting"
+    )
+    assert rule["defaultConfiguration"]["level"] == "error"
+    assert rule["helpUri"] == "https://gixy.io/plugins/http_splitting/"
+
+
+def test_no_issues_produces_empty_run():
+    log = _format("/etc/nginx/nginx.conf", "worker_processes auto;\n")
+
+    assert log["runs"][0]["results"] == []
+    assert log["runs"][0]["tool"]["driver"]["rules"] == []
+
+
+def test_to_uri_relativizes_paths_under_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(str(tmp_path))
+    assert _to_uri(str(tmp_path / "conf.d" / "site.conf")) == "conf.d/site.conf"
+    assert _to_uri("/somewhere/else/nginx.conf") == "/somewhere/else/nginx.conf"

--- a/tests/formatters/test_sarif.py
+++ b/tests/formatters/test_sarif.py
@@ -69,6 +69,22 @@ def test_sarif_result_fields():
     assert rule["helpUri"] == "https://gixy.io/plugins/http_splitting/"
 
 
+def test_stdin_results_have_no_location():
+    # main.py audits stdin as "<stdin>" and feeds the formatter with "-";
+    # neither is a valid SARIF artifact URI, so no location should be emitted
+    manager = Manager()
+    manager.audit("<stdin>", io.StringIO(SPLITTING_CONFIG), is_stdin=True)
+    formatter = SarifFormatter()
+    formatter.feed("-", manager)
+    log = json.loads(formatter.flush())
+
+    results = [
+        r for r in log["runs"][0]["results"] if r["ruleId"] == "http_splitting"
+    ]
+    assert len(results) == 1
+    assert "locations" not in results[0]
+
+
 def test_no_issues_produces_empty_run():
     log = _format("/etc/nginx/nginx.conf", "worker_processes auto;\n")
 


### PR DESCRIPTION
Supersedes the SARIF half of #74 by @grishxnder (their fork descends from yandex/gixy, so maintainer edits couldn't be pushed to it). Their original work is preserved with authorship. Directory scanning, which was previously part of this PR, is now split out into #76.

## Features

* `-f sarif`: SARIF 2.1.0 output for GitHub code scanning and similar tooling, with `security-severity` scores and per-issue reasons in result messages.

## Cleanup relative to #74

* Removed unrelated changes (urllib3 warning filter, venv `.gitignore` entries).
* SARIF fixes: valid OASIS schema URL, `informationUri` -> gixy.io, no invalid `"<stdin>"` artifact URIs.
* Rule metadata (`defaultConfiguration.level`, `security-severity`) follows the highest-severity issue of a rule instead of whichever issue was walked first, so GitHub doesn't bucket HIGH alerts as Medium.
* Artifact URIs are anchored to an explicit `SRCROOT` base via `originalUriBaseIds` (relative under the working directory, `file://` otherwise) instead of ambient-CWD relativization.
* Docs (README, usage, index, configuration) and 7 new tests.

## AI disclosure

Rework of #74 done with AI assistance (Claude Code), directed and reviewed by @MegaManSec.