### PR TITLE
feat: add recursive directory scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ gixy /opt/nginx.conf
 
 ### Scan a directory
 
-Instead of a single file, you can point `gixy` at a directory. It will recursively scan it for `nginx.conf` and any other `*.conf` files (skipping VCS/dependency directories like `.git` and `node_modules`) and analyze each one found:
+Instead of a single file, you can point `gixy` at a directory. It will recursively scan it for `*.conf` files (skipping VCS/dependency directories like `.git` and `node_modules`) and analyze each one found:
 
 ```shell-session
 # Recursively find and scan every *.conf file under /etc/nginx

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ gixy
 gixy /opt/nginx.conf
 ```
 
+### Scan a directory
+
+Instead of a single file, you can point `gixy` at a directory. It will recursively scan it for `nginx.conf` and any other `*.conf` files (skipping VCS/dependency directories like `.git` and `node_modules`) and analyze each one found:
+
+```shell-session
+# Recursively find and scan every *.conf file under /etc/nginx
+gixy /etc/nginx
+```
+
 You can also export your NGINX configuration to a single dump file (see [nginx -T Live Configuration Dump](https://gixy.io/nginx-config-dump)):
 
 ```shell-session

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -30,6 +30,13 @@ gixy
 gixy /opt/nginx.conf
 ```
 
+Instead of a single file, you can point `gixy` at a directory. It will recursively scan it for `*.conf` files (skipping VCS/dependency directories like `.git` and `node_modules`) and analyze each one found:
+
+```shell-session
+# Recursively find and scan every *.conf file under /etc/nginx
+gixy /etc/nginx
+```
+
 You can also export your NGINX configuration to a single dump file (see [nginx -T Live Configuration Dump](https://gixy.io/nginx-config-dump)):
 
 ```shell-session

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -31,7 +31,7 @@ cat /opt/nginx/nginx.conf | gixy -
 
 ## Scan a directory of configs
 
-You can also point `gixy` at a directory instead of a single file. It will recursively walk it looking for `nginx.conf` and any other `*.conf` files, skipping directories like `.git`, `.hg`, `.svn`, `node_modules`, `__pycache__`, and other dotdirs, and then scan every config file it finds:
+You can also point `gixy` at a directory instead of a single file. It will recursively walk it looking for `*.conf` files, skipping VCS/dependency directories (`.git`, `.hg`, `.svn`, `node_modules`, `__pycache__`, and hidden directories), and scan every config file it finds:
 
 ```shell-session
 # Recursively scan every *.conf file under /etc/nginx

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -29,6 +29,17 @@ gixy /opt/nginx/nginx.conf
 cat /opt/nginx/nginx.conf | gixy -
 ```
 
+## Scan a directory of configs
+
+You can also point `gixy` at a directory instead of a single file. It will recursively walk it looking for `nginx.conf` and any other `*.conf` files, skipping directories like `.git`, `.hg`, `.svn`, `node_modules`, `__pycache__`, and other dotdirs, and then scan every config file it finds:
+
+```shell-session
+# Recursively scan every *.conf file under /etc/nginx
+gixy /etc/nginx
+```
+
+Each discovered file is analyzed independently and reported under its own path, so this works well for scanning `sites-available`/`conf.d`-style layouts in one go instead of listing every file by hand.
+
 ## Scan a rendered config dump
 
 One of the easiest ways to get consistent results from `gixy` is to scan the fully rendered live configuration that NGINX sees (see [nginx -T Live Configuration Dump](https://gixy.io/nginx-config-dump)). NGINX can print that with `nginx -T`.

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -38,7 +38,7 @@ You can also point `gixy` at a directory instead of a single file. It will recur
 gixy /etc/nginx
 ```
 
-Configs are audited shallowest-first, and a discovered file that has already been covered by an earlier config's `include` is not audited again on its own. A typical layout where `nginx.conf` includes `conf.d/*.conf` therefore produces a single report per finding, with each fragment analyzed in the context of the config that includes it.
+A discovered file that another discovered config `include`s is not audited on its own. A typical layout where `nginx.conf` includes `conf.d/*.conf` therefore produces a single report per finding, with each fragment analyzed in the context of the config that includes it. Files listed explicitly on the command line are always audited, even when a scanned directory covers them too.
 
 ## Scan a rendered config dump
 

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -38,7 +38,7 @@ You can also point `gixy` at a directory instead of a single file. It will recur
 gixy /etc/nginx
 ```
 
-Each discovered file is analyzed independently and reported under its own path, so this works well for scanning `sites-available`/`conf.d`-style layouts in one go instead of listing every file by hand.
+Configs are audited shallowest-first, and a discovered file that has already been covered by an earlier config's `include` is not audited again on its own. A typical layout where `nginx.conf` includes `conf.d/*.conf` therefore produces a single report per finding, with each fragment analyzed in the context of the config that includes it.
 
 ## Scan a rendered config dump
 

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -40,6 +40,8 @@ gixy /etc/nginx
 
 A discovered file that another discovered config `include`s is not audited on its own. A typical layout where `nginx.conf` includes `conf.d/*.conf` therefore produces a single report per finding, with each fragment analyzed in the context of the config that includes it. Files listed explicitly on the command line are always audited, even when a scanned directory covers them too.
 
+A discovered file that isn't valid NGINX configuration — say a stray logrotate or supervisord `.conf` swept up by the walk — is skipped with a warning rather than failing the scan, and a directory argument containing no `*.conf` files only produces a warning as long as another argument yields something to audit.
+
 ## Scan a rendered config dump
 
 One of the easiest ways to get consistent results from `gixy` is to scan the fully rendered live configuration that NGINX sees (see [nginx -T Live Configuration Dump](https://gixy.io/nginx-config-dump)). NGINX can print that with `nginx -T`.

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -31,7 +31,7 @@ cat /opt/nginx/nginx.conf | gixy -
 
 ## Scan a directory of configs
 
-You can also point `gixy` at a directory instead of a single file. It will recursively walk it looking for `*.conf` files, skipping VCS/dependency directories (`.git`, `.hg`, `.svn`, `node_modules`, `__pycache__`, and hidden directories), and scan every config file it finds:
+You can also point `gixy` at a directory instead of a single file. It will recursively walk it looking for `*.conf` files, skipping VCS/dependency directories (`.git`, `.hg`, `.svn`, `node_modules`, `__pycache__`, and hidden directories), and scan every config file it finds. Symlinks are followed, but each config is only scanned once, so `sites-enabled/`-style symlink layouts don't produce duplicate reports:
 
 ```shell-session
 # Recursively scan every *.conf file under /etc/nginx

--- a/gixy/cli/main.py
+++ b/gixy/cli/main.py
@@ -49,7 +49,63 @@ def _collect_nginx_configs(directory):
                 continue
             seen_files.add(real_path)
             found.append(path)
-    return sorted(found)
+    # Shallower configs first, so entry points like nginx.conf are audited
+    # before the fragments they include.
+    return sorted(found, key=lambda path: (path.count(os.sep), path))
+
+
+def _files_in_config(block):
+    """Yield the real path of every file referenced by a parsed config tree."""
+    for child in block.children:
+        if child.file:
+            yield os.path.realpath(child.file)
+        if child.is_block:
+            yield from _files_in_config(child)
+
+
+def _expand_input_paths(input_paths):
+    """Expand CLI path arguments into the configs to audit.
+
+    Returns the list of paths plus the subset that came from directory scans,
+    which may be skipped later if an earlier config covers them via include.
+    """
+    nginx_files = []
+    discovered = set()
+
+    for input_path in input_paths:
+        if input_path == gixy.STDIN_ARG:
+            if len(input_paths) > 1:
+                sys.stderr.write("Expected either file paths or stdin, got both.\n")
+                sys.exit(1)
+
+            nginx_files.append(gixy.STDIN_ARG)
+            continue
+
+        path = os.path.abspath(os.path.expanduser(input_path))
+
+        if not os.path.exists(path):
+            sys.stderr.write(
+                "File {path!r} was not found.\nPlease specify correct path to configuration.\n".format(
+                    path=path
+                )
+            )
+            sys.exit(1)
+
+        if os.path.isdir(path):
+            found = _collect_nginx_configs(path)
+            if not found:
+                sys.stderr.write(
+                    "No nginx configuration files (*.conf) were found under directory {path!r}.\n".format(
+                        path=path
+                    )
+                )
+                sys.exit(1)
+            discovered.update(found)
+            nginx_files.extend(found)
+        else:
+            nginx_files.append(path)
+
+    return nginx_files, discovered
 
 
 def _init_logger(debug=False):
@@ -243,39 +299,7 @@ def main():
     args = parser.parse_args()
     _init_logger(args.debug)
 
-    # generate a list of user-expanded absolute paths from the nginx_files input arguments
-    nginx_files = []
-
-    for input_path in args.nginx_files:
-        if input_path == gixy.STDIN_ARG:
-            if len(args.nginx_files) > 1:
-                sys.stderr.write("Expected either file paths or stdin, got both.\n")
-                sys.exit(1)
-
-            nginx_files.append(gixy.STDIN_ARG)
-        else:
-            path = os.path.abspath(os.path.expanduser(input_path))
-
-            if not os.path.exists(path):
-                sys.stderr.write(
-                    "File {path!r} was not found.\nPlease specify correct path to configuration.\n".format(
-                        path=path
-                    )
-                )
-                sys.exit(1)
-
-            if os.path.isdir(path):
-                found = _collect_nginx_configs(path)
-                if not found:
-                    sys.stderr.write(
-                        "No nginx configuration files (*.conf) were found under directory {path!r}.\n".format(
-                            path=path
-                        )
-                    )
-                    sys.exit(1)
-                nginx_files.extend(found)
-            else:
-                nginx_files.append(path)
+    nginx_files, discovered = _expand_input_paths(args.nginx_files)
 
     try:
         severity = gixy.severity.ALL[args.level]
@@ -343,7 +367,14 @@ def main():
 
     formatter = formatters()[config.output_format]()
     failed = False
+    audited = set()
     for path in nginx_files:
+        if path in discovered and os.path.realpath(path) in audited:
+            LOG.debug(
+                'Skipping "%s": already analyzed as part of another configuration',
+                path,
+            )
+            continue
         with Gixy(config=config) as yoda:
             try:
                 if path == gixy.STDIN_ARG:
@@ -355,6 +386,8 @@ def main():
             except InvalidConfiguration:
                 failed = True
             formatter.feed(path, yoda)
+            if discovered and yoda.root is not None:
+                audited.update(_files_in_config(yoda.root))
             failed = failed or sum(yoda.stats.values()) > 0
 
     if args.output_file:

--- a/gixy/cli/main.py
+++ b/gixy/cli/main.py
@@ -4,6 +4,7 @@ import argparse
 import copy
 import logging
 import os
+import re
 import sys
 
 import gixy
@@ -15,6 +16,28 @@ from gixy.core.plugins_manager import PluginsManager
 from gixy.formatters import get_all as formatters
 
 LOG = logging.getLogger()
+
+# Directories that are never worth descending into when scanning a repo for configs.
+_IGNORED_DIR_NAMES = {".git", ".hg", ".svn", "node_modules", "__pycache__"}
+_CONFIG_FILENAME_RE = re.compile(r".*\.conf$", re.IGNORECASE)
+
+
+def _is_nginx_config_candidate(filename):
+    """Heuristic check for whether a file looks like an nginx config file."""
+    return filename.lower() == "nginx.conf" or bool(_CONFIG_FILENAME_RE.match(filename))
+
+
+def _collect_nginx_configs(directory):
+    """Recursively find likely nginx configuration files under a directory."""
+    found = []
+    for root, dirs, files in os.walk(directory):
+        dirs[:] = [
+            d for d in dirs if d not in _IGNORED_DIR_NAMES and not d.startswith(".")
+        ]
+        for filename in files:
+            if _is_nginx_config_candidate(filename):
+                found.append(os.path.join(root, filename))
+    return sorted(found)
 
 
 def _init_logger(debug=False):
@@ -86,7 +109,8 @@ def _get_cli_parser():
         type=str,
         default=["/etc/nginx/nginx.conf"],
         metavar="nginx.conf",
-        help="Path to nginx.conf, e.g. /etc/nginx/nginx.conf or - for stdin",
+        help="Path to nginx.conf, e.g. /etc/nginx/nginx.conf, a directory to scan "
+        "recursively for *.conf files, or - for stdin",
     )
 
     parser.add_argument(
@@ -228,7 +252,18 @@ def main():
                 )
                 sys.exit(1)
 
-            nginx_files.append(path)
+            if os.path.isdir(path):
+                found = _collect_nginx_configs(path)
+                if not found:
+                    sys.stderr.write(
+                        "No nginx configuration files (*.conf) were found under directory {path!r}.\n".format(
+                            path=path
+                        )
+                    )
+                    sys.exit(1)
+                nginx_files.extend(found)
+            else:
+                nginx_files.append(path)
 
     try:
         severity = gixy.severity.ALL[args.level]

--- a/gixy/cli/main.py
+++ b/gixy/cli/main.py
@@ -13,6 +13,7 @@ from gixy.core.exceptions import InvalidConfiguration
 from gixy.core.manager import Manager as Gixy
 from gixy.core.plugins_manager import PluginsManager
 from gixy.formatters import get_all as formatters
+from gixy.parser.nginx_parser import NginxParser
 
 LOG = logging.getLogger()
 
@@ -49,28 +50,61 @@ def _collect_nginx_configs(directory):
                 continue
             seen_files.add(real_path)
             found.append(path)
-    # Shallower configs first, so entry points like nginx.conf are audited
-    # before the fragments they include.
+    # Shallower configs first, so entry points like nginx.conf lead the report
     return sorted(found, key=lambda path: (path.count(os.sep), path))
 
 
-def _files_in_config(block):
-    """Yield the real path of every file referenced by a parsed config tree."""
-    for child in block.children:
-        if child.file:
-            yield os.path.realpath(child.file)
-        if child.is_block:
-            yield from _files_in_config(child)
+def _included_files(path):
+    """Real paths of the other files read from disk while parsing this config.
+
+    An nginx -T dump resolves includes against its own embedded records, not
+    the filesystem, so a dump never claims the files discovered next to it.
+    """
+    parser = NginxParser(cwd=os.path.dirname(path), allow_includes=True)
+    parser.parse_file(path)
+    return parser.parsed_files - {os.path.realpath(path)}
+
+
+def _select_entry_points(discovered, allow_includes):
+    """Pick the discovered configs to audit standalone.
+
+    Parses each discovered file once to build the include graph: a file that
+    another discovered config includes is analyzed in its includer's context
+    instead of standalone, so findings aren't reported twice.
+    """
+    if not allow_includes:
+        return set(discovered)
+
+    included = set()
+    for path in sorted(discovered):
+        try:
+            included.update(_included_files(path))
+        except InvalidConfiguration:
+            pass
+
+    entry_points = {
+        path for path in discovered if os.path.realpath(path) not in included
+    }
+    for path in sorted(discovered - entry_points):
+        LOG.debug(
+            'Skipping "%s": another scanned configuration includes it', path
+        )
+    # A pathological include cycle can claim every file; better to audit them
+    # all than none.
+    return entry_points or set(discovered)
 
 
 def _expand_input_paths(input_paths):
     """Expand CLI path arguments into the configs to audit.
 
-    Returns the list of paths plus the subset that came from directory scans,
-    which may be skipped later if an earlier config covers them via include.
+    Returns an ordered mapping of path -> whether it came from a directory
+    scan. Scan discoveries may later be skipped when another scanned config
+    includes them; explicitly listed files and stdin are always audited, and
+    an explicit file wins over a scan discovery of the same path.
+    Overlapping directory arguments are deduplicated by real path.
     """
-    nginx_files = []
-    discovered = set()
+    nginx_files = {}
+    seen_files = set()
 
     for input_path in input_paths:
         if input_path == gixy.STDIN_ARG:
@@ -78,7 +112,7 @@ def _expand_input_paths(input_paths):
                 sys.stderr.write("Expected either file paths or stdin, got both.\n")
                 sys.exit(1)
 
-            nginx_files.append(gixy.STDIN_ARG)
+            nginx_files[gixy.STDIN_ARG] = False
             continue
 
         path = os.path.abspath(os.path.expanduser(input_path))
@@ -100,12 +134,17 @@ def _expand_input_paths(input_paths):
                     )
                 )
                 sys.exit(1)
-            discovered.update(found)
-            nginx_files.extend(found)
+            for file_path in found:
+                real_path = os.path.realpath(file_path)
+                if real_path in seen_files:
+                    continue
+                seen_files.add(real_path)
+                nginx_files.setdefault(file_path, True)
         else:
-            nginx_files.append(path)
+            seen_files.add(os.path.realpath(path))
+            nginx_files[path] = False
 
-    return nginx_files, discovered
+    return nginx_files
 
 
 def _init_logger(debug=False):
@@ -299,7 +338,7 @@ def main():
     args = parser.parse_args()
     _init_logger(args.debug)
 
-    nginx_files, discovered = _expand_input_paths(args.nginx_files)
+    nginx_files = _expand_input_paths(args.nginx_files)
 
     try:
         severity = gixy.severity.ALL[args.level]
@@ -365,15 +404,17 @@ def main():
             options[opt_key] = val
         config.set_for(name, options)
 
+    discovered = {path for path, from_scan in nginx_files.items() if from_scan}
+    entry_points = (
+        _select_entry_points(discovered, config.allow_includes)
+        if discovered
+        else set()
+    )
+
     formatter = formatters()[config.output_format]()
     failed = False
-    audited = set()
-    for path in nginx_files:
-        if path in discovered and os.path.realpath(path) in audited:
-            LOG.debug(
-                'Skipping "%s": already analyzed as part of another configuration',
-                path,
-            )
+    for path, from_scan in nginx_files.items():
+        if from_scan and path not in entry_points:
             continue
         with Gixy(config=config) as yoda:
             try:
@@ -386,8 +427,6 @@ def main():
             except InvalidConfiguration:
                 failed = True
             formatter.feed(path, yoda)
-            if discovered and yoda.root is not None:
-                audited.update(_files_in_config(yoda.root))
             failed = failed or sum(yoda.stats.values()) > 0
 
     if args.output_file:

--- a/gixy/cli/main.py
+++ b/gixy/cli/main.py
@@ -40,7 +40,7 @@ def _collect_nginx_configs(directory):
         dirs[:] = sorted(
             d for d in dirs if d not in _IGNORED_DIR_NAMES and not d.startswith(".")
         )
-        for filename in files:
+        for filename in sorted(files):
             if not filename.lower().endswith(".conf"):
                 continue
             path = os.path.join(root, filename)

--- a/gixy/cli/main.py
+++ b/gixy/cli/main.py
@@ -70,28 +70,41 @@ def _select_entry_points(discovered, allow_includes):
 
     Parses each discovered file once to build the include graph: a file that
     another discovered config includes is analyzed in its includer's context
-    instead of standalone, so findings aren't reported twice.
+    instead of standalone, so findings aren't reported twice. A file that
+    doesn't parse as nginx configuration (a foreign *.conf swept up by the
+    walk) is dropped with a warning instead of failing the run.
     """
     if not allow_includes:
         return set(discovered)
 
     included = set()
+    broken = set()
     for path in sorted(discovered):
         try:
             included.update(_included_files(path))
         except InvalidConfiguration:
-            pass
+            broken.add(path)
+            LOG.warning('Skipping "%s": not a valid nginx configuration', path)
 
+    candidates = discovered - broken
     entry_points = {
-        path for path in discovered if os.path.realpath(path) not in included
+        path for path in candidates if os.path.realpath(path) not in included
     }
-    for path in sorted(discovered - entry_points):
+    for path in sorted(candidates - entry_points):
         LOG.debug(
             'Skipping "%s": another scanned configuration includes it', path
         )
     # A pathological include cycle can claim every file; better to audit them
     # all than none.
-    return entry_points or set(discovered)
+    return entry_points or candidates
+
+
+def _plan_scanned_audits(nginx_files, allow_includes):
+    """Entry points for the directory-scan subset of the expanded paths."""
+    discovered = {path for path, from_scan in nginx_files.items() if from_scan}
+    if not discovered:
+        return set()
+    return _select_entry_points(discovered, allow_includes)
 
 
 def _expand_input_paths(input_paths):
@@ -101,7 +114,9 @@ def _expand_input_paths(input_paths):
     scan. Scan discoveries may later be skipped when another scanned config
     includes them; explicitly listed files and stdin are always audited, and
     an explicit file wins over a scan discovery of the same path.
-    Overlapping directory arguments are deduplicated by real path.
+    Overlapping directory arguments are deduplicated by real path. A
+    directory without any *.conf files only warns; the run aborts only when
+    no argument yields anything to audit.
     """
     nginx_files = {}
     seen_files = set()
@@ -133,7 +148,7 @@ def _expand_input_paths(input_paths):
                         path=path
                     )
                 )
-                sys.exit(1)
+                continue
             for file_path in found:
                 real_path = os.path.realpath(file_path)
                 if real_path in seen_files:
@@ -143,6 +158,10 @@ def _expand_input_paths(input_paths):
         else:
             seen_files.add(os.path.realpath(path))
             nginx_files[path] = False
+
+    if not nginx_files:
+        sys.stderr.write("Nothing to audit: the given paths contain no configuration files.\n")
+        sys.exit(1)
 
     return nginx_files
 
@@ -404,12 +423,7 @@ def main():
             options[opt_key] = val
         config.set_for(name, options)
 
-    discovered = {path for path, from_scan in nginx_files.items() if from_scan}
-    entry_points = (
-        _select_entry_points(discovered, config.allow_includes)
-        if discovered
-        else set()
-    )
+    entry_points = _plan_scanned_audits(nginx_files, config.allow_includes)
 
     formatter = formatters()[config.output_format]()
     failed = False
@@ -425,6 +439,13 @@ def main():
                     with open(path, mode="rb") as fdata:
                         yoda.audit(path, fdata, is_stdin=False)
             except InvalidConfiguration:
+                if from_scan:
+                    # Reachable with --disable-includes, where no include
+                    # graph was built up front
+                    LOG.warning(
+                        'Skipping "%s": not a valid nginx configuration', path
+                    )
+                    continue
                 failed = True
             formatter.feed(path, yoda)
             failed = failed or sum(yoda.stats.values()) > 0

--- a/gixy/cli/main.py
+++ b/gixy/cli/main.py
@@ -4,7 +4,6 @@ import argparse
 import copy
 import logging
 import os
-import re
 import sys
 
 import gixy
@@ -19,23 +18,17 @@ LOG = logging.getLogger()
 
 # Directories that are never worth descending into when scanning a repo for configs.
 _IGNORED_DIR_NAMES = {".git", ".hg", ".svn", "node_modules", "__pycache__"}
-_CONFIG_FILENAME_RE = re.compile(r".*\.conf$", re.IGNORECASE)
-
-
-def _is_nginx_config_candidate(filename):
-    """Heuristic check for whether a file looks like an nginx config file."""
-    return filename.lower() == "nginx.conf" or bool(_CONFIG_FILENAME_RE.match(filename))
 
 
 def _collect_nginx_configs(directory):
-    """Recursively find likely nginx configuration files under a directory."""
+    """Recursively find *.conf files under a directory."""
     found = []
     for root, dirs, files in os.walk(directory):
         dirs[:] = [
             d for d in dirs if d not in _IGNORED_DIR_NAMES and not d.startswith(".")
         ]
         for filename in files:
-            if _is_nginx_config_candidate(filename):
+            if filename.lower().endswith(".conf"):
                 found.append(os.path.join(root, filename))
     return sorted(found)
 

--- a/gixy/cli/main.py
+++ b/gixy/cli/main.py
@@ -21,15 +21,34 @@ _IGNORED_DIR_NAMES = {".git", ".hg", ".svn", "node_modules", "__pycache__"}
 
 
 def _collect_nginx_configs(directory):
-    """Recursively find *.conf files under a directory."""
+    """Recursively find *.conf files under a directory, following symlinks.
+
+    Directories and files are deduplicated by their real path, so a symlink
+    cycle cannot hang the walk and layouts like sites-enabled/x.conf ->
+    sites-available/x.conf yield the file only once.
+    """
     found = []
-    for root, dirs, files in os.walk(directory):
-        dirs[:] = [
+    seen_dirs = set()
+    seen_files = set()
+    for root, dirs, files in os.walk(directory, followlinks=True):
+        real_root = os.path.realpath(root)
+        if real_root in seen_dirs:
+            dirs[:] = []
+            continue
+        seen_dirs.add(real_root)
+        # Sorted so that dedup by real path is deterministic
+        dirs[:] = sorted(
             d for d in dirs if d not in _IGNORED_DIR_NAMES and not d.startswith(".")
-        ]
+        )
         for filename in files:
-            if filename.lower().endswith(".conf"):
-                found.append(os.path.join(root, filename))
+            if not filename.lower().endswith(".conf"):
+                continue
+            path = os.path.join(root, filename)
+            real_path = os.path.realpath(path)
+            if real_path in seen_files:
+                continue
+            seen_files.add(real_path)
+            found.append(path)
     return sorted(found)
 
 

--- a/gixy/parser/nginx_parser.py
+++ b/gixy/parser/nginx_parser.py
@@ -24,6 +24,10 @@ class NginxParser(object):
         self._init_directives()
         self._path_stack = None
         self._active_includes = set()
+        # Real paths of every file read from disk, includes and all. Unlike
+        # node attribution this also covers files that contribute no
+        # directives of their own (e.g. a file holding a single include).
+        self.parsed_files = set()
 
     def parse_file(self, path, root=None, display_path=None):
         """Parse an nginx configuration file from disk.
@@ -42,6 +46,7 @@ class NginxParser(object):
         real_path = display_path if display_path else path
         LOG.debug("Parse file: {0}".format(real_path))
         root = self._ensure_root(root)
+        self.parsed_files.add(os.path.realpath(path))
         try:
             parsed = self.parser.parse_path(path)
         except ParseException as e:

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -205,6 +205,52 @@ def test_overlapping_directory_arguments_audit_files_once(tmp_path):
     assert len(issues) == 1
 
 
+def test_foreign_conf_files_do_not_fail_the_scan(tmp_path):
+    root = str(tmp_path)
+    _write(os.path.join(root, "nginx.conf"), "worker_processes auto;\n")
+    _write(os.path.join(root, "supervisord.conf"), "[program:x]\ncommand=/bin/true\n")
+
+    proc = _run_gixy(root)
+
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout.decode("utf-8")) == []
+    assert "supervisord.conf" in proc.stderr.decode("utf-8")
+
+
+def test_foreign_conf_files_are_skipped_with_disabled_includes(tmp_path):
+    root = str(tmp_path)
+    _write(os.path.join(root, "nginx.conf"), "worker_processes auto;\n")
+    _write(os.path.join(root, "supervisord.conf"), "[program:x]\ncommand=/bin/true\n")
+
+    proc = _run_gixy(root, "--disable-includes")
+
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout.decode("utf-8")) == []
+
+
+def test_empty_directory_argument_does_not_abort_the_run(tmp_path):
+    root = str(tmp_path)
+    empty = os.path.join(root, "empty")
+    os.makedirs(empty)
+    scanned = os.path.join(root, "scanned")
+    _write(os.path.join(scanned, "vuln.conf"), VULN_SERVER)
+
+    proc = _run_gixy(empty, scanned)
+
+    assert len(_splitting_issues(proc)) == 1
+    assert "empty" in proc.stderr.decode("utf-8")
+
+
+def test_only_empty_directories_exit_nonzero(tmp_path):
+    empty = os.path.join(str(tmp_path), "empty")
+    os.makedirs(empty)
+
+    proc = _run_gixy(empty)
+
+    assert proc.returncode == 1
+    assert "Nothing to audit" in proc.stderr.decode("utf-8")
+
+
 def test_select_entry_points_drops_included_configs(tmp_path):
     root = str(tmp_path)
     fragment = os.path.join(root, "aaa.conf")

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -3,7 +3,15 @@ import os
 import subprocess
 import sys
 
-from gixy.cli.main import _collect_nginx_configs
+from gixy.cli.main import _collect_nginx_configs, _select_entry_points
+
+VULN_SERVER = (
+    "server {\n"
+    "    location ~ /v1/((?<action>[^.]*)\\.json)?$ {\n"
+    "        add_header X-Action $action;\n"
+    "    }\n"
+    "}\n"
+)
 
 
 def _write(path, content):
@@ -16,6 +24,22 @@ def _touch(path):
     _write(path, "# test\n")
 
 
+def _run_gixy(*args):
+    return subprocess.run(
+        [sys.executable, "-m", "gixy", *args, "-f", "json"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _splitting_issues(proc):
+    return [
+        i
+        for i in json.loads(proc.stdout.decode("utf-8"))
+        if i["plugin"] == "http_splitting"
+    ]
+
+
 def test_collects_conf_files_recursively_shallowest_first(tmp_path):
     root = str(tmp_path)
     _touch(os.path.join(root, "nginx.conf"))
@@ -24,8 +48,8 @@ def test_collects_conf_files_recursively_shallowest_first(tmp_path):
 
     found = _collect_nginx_configs(root)
 
-    # Shallower configs come first so entry points are audited before
-    # the fragments they include
+    # Shallower configs come first so entry points like nginx.conf lead
+    # the report
     assert found == [
         os.path.join(root, "nginx.conf"),
         os.path.join(root, "conf.d", "site.conf"),
@@ -93,28 +117,111 @@ def test_skips_vcs_dependency_and_hidden_directories(tmp_path):
 def test_directory_scan_reports_included_files_only_once(tmp_path):
     root = str(tmp_path)
     _write(os.path.join(root, "nginx.conf"), "http {\n    include conf.d/*.conf;\n}\n")
-    _write(
-        os.path.join(root, "conf.d", "vuln.conf"),
-        "server {\n"
-        "    location ~ /v1/((?<action>[^.]*)\\.json)?$ {\n"
-        "        add_header X-Action $action;\n"
-        "    }\n"
-        "}\n",
-    )
+    _write(os.path.join(root, "conf.d", "vuln.conf"), VULN_SERVER)
 
-    proc = subprocess.run(
-        [sys.executable, "-m", "gixy", root, "-f", "json"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    issues = [
-        i
-        for i in json.loads(proc.stdout.decode("utf-8"))
-        if i["plugin"] == "http_splitting"
-    ]
+    issues = _splitting_issues(_run_gixy(root))
 
     # vuln.conf is covered by nginx.conf's include, so it must not
     # additionally be audited standalone
     assert len(issues) == 1
     assert issues[0]["path"].endswith("nginx.conf")
     assert issues[0]["file"].endswith("vuln.conf")
+
+
+def test_includer_sorted_after_its_fragment_still_covers_it(tmp_path):
+    # zzz.conf includes aaa.conf: even though the fragment sorts first,
+    # it must only be reported through its includer
+    root = str(tmp_path)
+    _write(os.path.join(root, "aaa.conf"), VULN_SERVER)
+    _write(os.path.join(root, "zzz.conf"), "http {\n    include aaa.conf;\n}\n")
+
+    issues = _splitting_issues(_run_gixy(root))
+
+    assert len(issues) == 1
+    assert issues[0]["path"].endswith("zzz.conf")
+
+
+def test_include_only_wrapper_is_not_audited_standalone(tmp_path):
+    # wrapper.conf contributes no directives of its own, only an include;
+    # it still must not be re-audited standalone
+    root = str(tmp_path)
+    _write(os.path.join(root, "nginx.conf"), "http {\n    include wrapper.conf;\n}\n")
+    _write(os.path.join(root, "wrapper.conf"), "include conf.d/real.conf;\n")
+    _write(os.path.join(root, "conf.d", "real.conf"), VULN_SERVER)
+
+    issues = _splitting_issues(_run_gixy(root))
+
+    assert len(issues) == 1
+    assert issues[0]["path"].endswith("nginx.conf")
+
+
+def test_config_dump_does_not_suppress_live_configs(tmp_path):
+    # An nginx -T dump resolves includes against its own records, so it must
+    # not claim the live files its records happen to be named after
+    root = str(tmp_path)
+    live = os.path.join(root, "conf.d", "site.conf")
+    _write(live, VULN_SERVER)
+    _write(
+        os.path.join(root, "dump.conf"),
+        "# configuration file {root}/live-nginx.conf:\n"
+        "http {{\n"
+        "    include {root}/conf.d/*.conf;\n"
+        "}}\n"
+        "# configuration file {live}:\n"
+        "{vuln}".format(root=root, live=live, vuln=VULN_SERVER),
+    )
+
+    issues = _splitting_issues(_run_gixy(root))
+
+    # One finding through the dump, and one from the live file itself
+    assert sorted(i["path"] for i in issues) == [
+        live,
+        os.path.join(root, "dump.conf"),
+    ]
+
+
+def test_explicit_file_is_audited_even_when_a_scanned_directory_covers_it(tmp_path):
+    root = str(tmp_path)
+    site = os.path.join(root, "conf.d", "site.conf")
+    _write(os.path.join(root, "nginx.conf"), "http {\n    include conf.d/*.conf;\n}\n")
+    _write(site, VULN_SERVER)
+
+    issues = _splitting_issues(_run_gixy(root, site))
+
+    # Once in nginx.conf's context, once standalone as explicitly requested
+    assert sorted(i["path"] for i in issues) == [
+        site,
+        os.path.join(root, "nginx.conf"),
+    ]
+
+
+def test_overlapping_directory_arguments_audit_files_once(tmp_path):
+    root = str(tmp_path)
+    sub = os.path.join(root, "sub")
+    _write(os.path.join(sub, "vuln.conf"), VULN_SERVER)
+
+    issues = _splitting_issues(_run_gixy(root, sub))
+
+    assert len(issues) == 1
+
+
+def test_select_entry_points_drops_included_configs(tmp_path):
+    root = str(tmp_path)
+    fragment = os.path.join(root, "aaa.conf")
+    includer = os.path.join(root, "zzz.conf")
+    _write(fragment, VULN_SERVER)
+    _write(includer, "http {\n    include aaa.conf;\n}\n")
+
+    assert _select_entry_points({fragment, includer}, True) == {includer}
+    # Without include processing every file stands alone
+    assert _select_entry_points({fragment, includer}, False) == {fragment, includer}
+
+
+def test_select_entry_points_keeps_include_cycles_auditable(tmp_path):
+    root = str(tmp_path)
+    a = os.path.join(root, "a.conf")
+    b = os.path.join(root, "b.conf")
+    _write(a, "include b.conf;\n")
+    _write(b, "include a.conf;\n")
+
+    assert _select_entry_points({a, b}, True) == {a, b}

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,15 +1,22 @@
+import json
 import os
+import subprocess
+import sys
 
 from gixy.cli.main import _collect_nginx_configs
 
 
-def _touch(path):
+def _write(path, content):
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w") as f:
-        f.write("# test\n")
+        f.write(content)
 
 
-def test_collects_conf_files_recursively(tmp_path):
+def _touch(path):
+    _write(path, "# test\n")
+
+
+def test_collects_conf_files_recursively_shallowest_first(tmp_path):
     root = str(tmp_path)
     _touch(os.path.join(root, "nginx.conf"))
     _touch(os.path.join(root, "conf.d", "site.conf"))
@@ -17,9 +24,11 @@ def test_collects_conf_files_recursively(tmp_path):
 
     found = _collect_nginx_configs(root)
 
+    # Shallower configs come first so entry points are audited before
+    # the fragments they include
     assert found == [
-        os.path.join(root, "conf.d", "site.conf"),
         os.path.join(root, "nginx.conf"),
+        os.path.join(root, "conf.d", "site.conf"),
         os.path.join(root, "sites-available", "example.conf"),
     ]
 
@@ -79,3 +88,33 @@ def test_skips_vcs_dependency_and_hidden_directories(tmp_path):
         _touch(os.path.join(root, skipped, "ignored.conf"))
 
     assert _collect_nginx_configs(root) == [os.path.join(root, "nginx.conf")]
+
+
+def test_directory_scan_reports_included_files_only_once(tmp_path):
+    root = str(tmp_path)
+    _write(os.path.join(root, "nginx.conf"), "http {\n    include conf.d/*.conf;\n}\n")
+    _write(
+        os.path.join(root, "conf.d", "vuln.conf"),
+        "server {\n"
+        "    location ~ /v1/((?<action>[^.]*)\\.json)?$ {\n"
+        "        add_header X-Action $action;\n"
+        "    }\n"
+        "}\n",
+    )
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "gixy", root, "-f", "json"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    issues = [
+        i
+        for i in json.loads(proc.stdout.decode("utf-8"))
+        if i["plugin"] == "http_splitting"
+    ]
+
+    # vuln.conf is covered by nginx.conf's include, so it must not
+    # additionally be audited standalone
+    assert len(issues) == 1
+    assert issues[0]["path"].endswith("nginx.conf")
+    assert issues[0]["file"].endswith("vuln.conf")

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -39,6 +39,39 @@ def test_ignores_non_conf_files(tmp_path):
     assert _collect_nginx_configs(root) == []
 
 
+def test_follows_directory_symlinks(tmp_path):
+    root = str(tmp_path)
+    outside = str(tmp_path.parent / (tmp_path.name + "-outside"))
+    _touch(os.path.join(outside, "linked.conf"))
+    os.symlink(outside, os.path.join(root, "linked"))
+
+    assert _collect_nginx_configs(root) == [
+        os.path.join(root, "linked", "linked.conf")
+    ]
+
+
+def test_symlink_cycle_does_not_hang(tmp_path):
+    root = str(tmp_path)
+    _touch(os.path.join(root, "sub", "site.conf"))
+    os.symlink(root, os.path.join(root, "sub", "loop"))
+
+    assert _collect_nginx_configs(root) == [os.path.join(root, "sub", "site.conf")]
+
+
+def test_deduplicates_file_symlinks(tmp_path):
+    root = str(tmp_path)
+    _touch(os.path.join(root, "sites-available", "example.conf"))
+    os.makedirs(os.path.join(root, "sites-enabled"))
+    os.symlink(
+        os.path.join(root, "sites-available", "example.conf"),
+        os.path.join(root, "sites-enabled", "example.conf"),
+    )
+
+    assert _collect_nginx_configs(root) == [
+        os.path.join(root, "sites-available", "example.conf")
+    ]
+
+
 def test_skips_vcs_dependency_and_hidden_directories(tmp_path):
     root = str(tmp_path)
     _touch(os.path.join(root, "nginx.conf"))

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,0 +1,48 @@
+import os
+
+from gixy.cli.main import _collect_nginx_configs
+
+
+def _touch(path):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write("# test\n")
+
+
+def test_collects_conf_files_recursively(tmp_path):
+    root = str(tmp_path)
+    _touch(os.path.join(root, "nginx.conf"))
+    _touch(os.path.join(root, "conf.d", "site.conf"))
+    _touch(os.path.join(root, "sites-available", "example.conf"))
+
+    found = _collect_nginx_configs(root)
+
+    assert found == [
+        os.path.join(root, "conf.d", "site.conf"),
+        os.path.join(root, "nginx.conf"),
+        os.path.join(root, "sites-available", "example.conf"),
+    ]
+
+
+def test_matches_conf_extension_case_insensitively(tmp_path):
+    root = str(tmp_path)
+    _touch(os.path.join(root, "UPPER.CONF"))
+
+    assert _collect_nginx_configs(root) == [os.path.join(root, "UPPER.CONF")]
+
+
+def test_ignores_non_conf_files(tmp_path):
+    root = str(tmp_path)
+    _touch(os.path.join(root, "README.md"))
+    _touch(os.path.join(root, "nginx.conf.bak"))
+
+    assert _collect_nginx_configs(root) == []
+
+
+def test_skips_vcs_dependency_and_hidden_directories(tmp_path):
+    root = str(tmp_path)
+    _touch(os.path.join(root, "nginx.conf"))
+    for skipped in (".git", ".hg", ".svn", "node_modules", "__pycache__", ".hidden"):
+        _touch(os.path.join(root, skipped, "ignored.conf"))
+
+    assert _collect_nginx_configs(root) == [os.path.join(root, "nginx.conf")]


### PR DESCRIPTION
Split out of #75; supersedes the directory-scanning half of #74 by @grishxnder (their original work is preserved with authorship). Rebased onto master after #75/#77 landed.

## Features

* Point `gixy` at a directory to recursively scan every `*.conf` under it. Symlinks are followed safely (real-path dedup, cycle-proof, deterministic); VCS/dependency/hidden dirs are skipped.
* Discovered configs are parsed once up front to build the include graph, and only its entry points are audited standalone: a file another discovered config `include`s is analyzed in its includer's context, so findings are reported exactly once. This holds regardless of filename ordering, for include-only wrapper files, and for `nginx -T` dumps sitting next to live configs (a dump resolves includes against its own records, so it never suppresses the live files). Explicitly listed files are always audited, and overlapping directory arguments are deduplicated by real path.
* Robust against non-nginx files: a foreign `*.conf` swept up by the walk (logrotate, supervisord, ...) is skipped with a warning instead of failing the run, and an empty directory argument only warns — the run aborts only if no argument yields anything to audit. Exit code 1 keeps meaning findings or a real error.

## Notes for review

* The only change outside `gixy/cli/` is `NginxParser.parsed_files`: the parser now records the real path of every file it reads from disk. The include graph needs this because AST node attribution misses files that contribute no directives of their own (e.g. a file containing a single `include`).
* With `--disable-includes` no include graph is built and every discovered file is audited standalone.

## Cleanup relative to #74

* Removed unrelated changes (urllib3 warning filter, venv `.gitignore` entries); simplified config discovery.
* Docs (README, usage, index) and 19 new tests covering the include-graph selection, dump/wrapper/ordering edge cases, and the skip/warning behavior.

## AI disclosure

Rework of #74 done with AI assistance (Claude Code), directed and reviewed by @MegaManSec.