### PR TITLE
chore: share the stdin sentinels between the CLI and the SARIF formatter

### DIFF
--- a/gixy/__init__.py
+++ b/gixy/__init__.py
@@ -3,3 +3,6 @@
 from gixy.core import severity
 
 version = "0.5.0"
+
+STDIN_ARG = "-"
+STDIN_NAME = "<stdin>"

--- a/gixy/cli/main.py
+++ b/gixy/cli/main.py
@@ -211,12 +211,12 @@ def main():
     nginx_files = []
 
     for input_path in args.nginx_files:
-        if input_path == "-":
+        if input_path == gixy.STDIN_ARG:
             if len(args.nginx_files) > 1:
                 sys.stderr.write("Expected either file paths or stdin, got both.\n")
                 sys.exit(1)
 
-            nginx_files.append("-")
+            nginx_files.append(gixy.STDIN_ARG)
         else:
             path = os.path.abspath(os.path.expanduser(input_path))
 
@@ -299,9 +299,9 @@ def main():
     for path in nginx_files:
         with Gixy(config=config) as yoda:
             try:
-                if path == "-":
+                if path == gixy.STDIN_ARG:
                     with os.fdopen(sys.stdin.fileno(), "rb") as fdata:
-                        yoda.audit("<stdin>", fdata, is_stdin=True)
+                        yoda.audit(gixy.STDIN_NAME, fdata, is_stdin=True)
                 else:
                     with open(path, mode="rb") as fdata:
                         yoda.audit(path, fdata, is_stdin=False)

--- a/gixy/formatters/sarif.py
+++ b/gixy/formatters/sarif.py
@@ -112,8 +112,7 @@ class SarifFormatter(BaseFormatter):
                     uri = location["file"]
                 else:
                     uri = path
-                if uri in ("-", "<stdin>"):
-                    # stdin has no artifact to point at, and "<stdin>" is not a valid URI
+                if uri in (gixy.STDIN_ARG, gixy.STDIN_NAME):
                     uri = None
 
                 if uri:


### PR DESCRIPTION
Follow-up to #75. The SARIF formatter hardcoded knowledge of the CLI's `"-"` path argument and `"<stdin>"` pseudo-path with no shared constant. This names them once in `gixy/__init__.py` (`STDIN_ARG`, `STDIN_NAME`) and uses them in both places, so the contract between the CLI and formatters is explicit and can't silently drift.

No behavior change; 768 tests pass and stdin SARIF output was smoke-tested (`nginx -T | gixy - -f sarif` still emits results without locations).

## AI disclosure

Done with AI assistance (Claude Code), directed and reviewed by @MegaManSec.